### PR TITLE
tools : Add script to check coding rules for .c and .h files.

### DIFF
--- a/tools/check-codingrules.sh
+++ b/tools/check-codingrules.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+#title           :check-codingrules.sh
+#description     :This script will check coding rules in all .c and .h files into mcu-firmware repository.
+#author          :stephen
+#date            :20181124
+#version         :1
+#usage           :./check-codingrules.sh
+#==============================================================================
+
+# WARNING : This script must to be in GITROOT/tools directory, it will not work if you copy it elsewhere.
+
+# Bash code to get the real dir of the script, even if it's called from another path.
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null && pwd )"
+
+UNCRUSTIFY_OUTPUT_DIR="${DIR}/../../uncrustify-output"
+
+CUR_DIR=$(pwd)
+cd "${DIR}/../"
+
+if [ -e "/usr/bin/uncrustify"]; then
+    echo "uncrustify binary not found, please install it. On Ubuntu : apt install uncrustify"
+    exit 1
+fi
+
+# Check *.c files
+BAD_FILES=""
+echo "Scan .c files ----"
+C_FILES=$(find . -name '*.c')
+for FILE in $C_FILES; do
+    uncrustify -c "$DIR/codingrules-uncrustify-riot.cfg" --check $FILE
+    if [ $? -eq 1 ]; then
+        BAD_FILES+="${FILE}"$'\n'
+    fi
+done
+
+# Check *.h files
+echo "Scan .h files ----"
+H_FILES=$(find . -name '*.h')
+for FILE in $H_FILES; do
+    uncrustify -c "$DIR/codingrules-uncrustify-riot.cfg" -l C --check $FILE
+    if [ $? -eq 1 ]; then
+        BAD_FILES+="${FILE}"$'\n'
+    fi
+done
+
+# Check result of scan
+if [ -z "${BAD_FILES[0]}" ]; then
+    echo "All files are good ! You are good to go"
+    exit 0
+else
+    read -n 1 -p "Some files aren't correct, do you want to automatically generate corrected file ? (y/N) " answer
+    [ -z "$answer" ] && answer="N"
+    if [ ${answer^^} = "Y" ]; then
+        echo -e "\n"
+        mkdir -p "$UNCRUSTIFY_OUTPUT_DIR"
+        # Output generated file into $UNCRUSTIFY_OUTPUT_DIR. The dir will have the same directory as the mcu repository
+        while read line; do
+            uncrustify -c "$DIR/codingrules-uncrustify-riot.cfg" --prefix "$UNCRUSTIFY_OUTPUT_DIR" -q $line
+        done <<< "$BAD_FILES"
+        echo "Done !"
+    else
+        echo -e "\n"
+        cd $CUR_DIR
+        echo "That's all folks !"
+        exit 0
+    fi
+
+    read -n 1 -p "Launch meld to check diff ? (y/N) " answer
+    [ -z "$answer" ] && answer="N"
+    if [ ${answer^^} = "Y" ]; then
+        echo -e "\n"
+        if [ -e /usr/bin/meld ]; then
+            meld "$DIR/../" "$UNCRUSTIFY_OUTPUT_DIR"
+        else
+            echo "meld binary not found, install it with : apt install meld"
+        fi
+    fi
+fi
+
+cd $CUR_DIR
+echo "That's all folks !"
+exit 0

--- a/tools/codingrules-uncrustify-riot.cfg
+++ b/tools/codingrules-uncrustify-riot.cfg
@@ -1,0 +1,84 @@
+indent_with_tabs        = 0                 # 1=indent to level only, 2=indent with tabs
+input_tab_size          = 4                 # original tab size
+output_tab_size         = 4                 # new tab size
+indent_columns          = output_tab_size   #
+indent_label            = 1                 # pos: absolute col, neg: relative column
+indent_switch_case      = 4                 # number
+indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
+
+#
+# inter-symbol newlines
+#
+
+nl_enum_brace          = remove   # "enum {" vs "enum \n {"
+nl_union_brace         = remove   # "union {" vs "union \n {"
+nl_struct_brace        = remove   # "struct {" vs "struct \n {"
+nl_do_brace            = remove   # "do {" vs "do \n {"
+nl_if_brace            = remove   # "if () {" vs "if () \n {"
+nl_for_brace           = remove   # "for () {" vs "for () \n {"
+nl_else_brace          = remove   # "else {" vs "else \n {"
+nl_while_brace         = remove   # "while () {" vs "while () \n {"
+nl_switch_brace        = remove   # "switch () {" vs "switch () \n {"
+nl_brace_while         = remove   # "} while" vs "} \n while" - cuddle while
+nl_brace_else          = add      # "} \n else" vs "} else"
+nl_func_var_def_blk    = 1        #
+nl_fcall_brace         = remove   # "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace          = add      # "int foo() {" vs "int foo()\n{"
+nl_collapse_empty_body = true     # set while(){\n} to while(){}
+nl_end_of_file         = add      # fix no newline at end of file
+nl_end_of_file_min     = 1        #
+
+#
+# Source code modifications
+#
+
+mod_paren_on_return        = ignore   # "return 1;" vs "return (1);"
+mod_full_brace_if          = add      # "if() { } else { }" vs "if() else"
+mod_full_brace_while       = force    # force while(); to while(){ \n ; }
+mod_full_brace_for         = force    # force for(); to for(){ \n ; }
+mod_remove_extra_semicolon = true     # remove superfluous semicolons.
+
+#
+# inter-character spacing options
+#
+
+sp_sizeof_paren         = remove   # "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen        = force    # "if (" vs "if("
+sp_after_sparen         = force    # "if () {" vs "if (){"
+sp_inside_braces        = add      # "{ 1 }" vs "{1}"
+sp_inside_braces_struct = add      # "{ 1 }" vs "{1}"
+sp_inside_braces_enum   = add      # "{ 1 }" vs "{1}"
+sp_assign               = add      #
+sp_arith                = add      #
+sp_bool                 = add      #
+sp_compare              = add      #
+sp_assign               = add      #
+sp_after_comma          = add      #
+sp_func_def_paren       = remove   # "int foo (){" vs "int foo(){"
+sp_func_call_paren      = remove   # "foo (" vs "foo("
+sp_func_proto_paren     = remove   # "int foo ();" vs "int foo();"
+sp_else_brace           = add      # ignore/add/remove/force
+sp_before_ptr_star      = add      # ignore/add/remove/force
+sp_after_ptr_star       = remove   # ignore/add/remove/force
+sp_between_ptr_star     = remove   # ignore/add/remove/force
+sp_inside_paren         = remove   # remove spaces inside parens
+sp_paren_paren          = remove   # remove spaces between nested parens
+sp_inside_sparen        = remove   # remove spaces inside parens for if, while and the like
+sp_inside_braces_empty  = remove   # force while(){ } to while(){}
+
+#
+# Aligning stuff
+#
+
+align_with_tabs        = FALSE     # use tabs to align
+align_on_tabstop       = TRUE      # align on tabstops
+align_enum_equ_span    = 4         # '=' in enum definition
+align_struct_init_span = 0         # align stuff in a structure init '= { }'
+align_right_cmt_span   = 3         #
+
+#
+# Special cases
+#
+
+set PROTO_WRAP ISR   # Wrap ISR macros like functions
+


### PR DESCRIPTION
	* Script based on uncrustify tools.
	* Use the same uncrustify configuration as RIOT-OS.

Signed-off-by: Stephen Clymans <stephen@clymans.fr>