### PR TITLE
Add communication between simulator and native firmware

### DIFF
--- a/boards/cogip2019-cortex-native/vl53l0x.c
+++ b/boards/cogip2019-cortex-native/vl53l0x.c
@@ -17,10 +17,14 @@
 
 /* Standard include */
 #include <stdio.h>
+#include <sys/shm.h>
 
 /* Project includes */
 #include "vl53l0x.h"
 #include "board.h"
+#include "platform.h"
+
+uint16_t *shm_ptr = NULL;
 
 int vl53l0x_init_dev(vl53l0x_t dev)
 {
@@ -49,8 +53,20 @@ void vl53l0x_init(void)
 
 uint16_t vl53l0x_continuous_ranging_get_measure(vl53l0x_t dev)
 {
-    (void) dev;
+    /* Try to initialize shared memory if not already done */
+    if(shm_ptr == NULL && pf_shm_key != 0) {
+        int shmid = shmget(pf_shm_key, VL53L0X_NUMOF*sizeof(uint16_t), 0);
+        shm_ptr = (uint16_t*) shmat(shmid,(void*)0,0);
+    }
 
-    return UINT16_MAX;
+    /* Return max value if shared memory is not initialized */
+    if(shm_ptr == NULL) {
+        return UINT16_MAX;
+    }
+
+    /* printf("Sensor %d = %d\n", dev, shm_ptr[dev]); */
+
+    /* Return value from simulator */
+    return shm_ptr[dev];
 }
 /** @} */

--- a/platforms/cortex/include/platform.h
+++ b/platforms/cortex/include/platform.h
@@ -72,7 +72,7 @@
 #define PF_START_COUNTDOWN  3
 
 /* Shell commands array size */
-#define NB_SHELL_COMMANDS   16
+#define NB_SHELL_COMMANDS   17
 
 /* Timeout before completely stop the robot once started */
 #define GAME_DURATION_SEC   100
@@ -103,7 +103,7 @@
 #define OBSTACLE_BORDER_Y_MIN   AVOIDANCE_BORDER_Y_MIN
 #define OBSTACLE_BORDER_Y_MAX   AVOIDANCE_BORDER_Y_MAX
 /* Obstacle size */
-#define OBSTACLE_DYN_SIZE                   800
+#define OBSTACLE_DYN_SIZE                   400
 /* Detection thresholds */
 #define OBSTACLE_DETECTION_MINIMUM_TRESHOLD 10
 #define OBSTACLE_DETECTION_MAXIMUM_TRESHOLD 200
@@ -229,6 +229,7 @@ struct shell_command_linked {
 };
 
 extern shell_command_linked_t pf_shell_commands;
+extern int pf_shm_key;
 
 /* TODO: These functions/structs should be moved to common code */
 void pf_push_shell_commands(shell_command_linked_t *shell_commands);
@@ -242,6 +243,7 @@ extern shell_command_t cmd_help_json;
 extern shell_command_t cmd_exit_shell;
 extern shell_command_t cmd_print_pose_current;
 extern shell_command_t cmd_print_dyn_obstacles;
+extern shell_command_t cmd_set_shm_key;
 
 path_t *pf_get_path(void);
 int pf_is_game_launched(void);

--- a/platforms/cortex/platform.c
+++ b/platforms/cortex/platform.c
@@ -121,15 +121,27 @@ int pf_print_pose_current(int argc, char **argv)
 
     printf(
         "{"
-        "\"mode\": \"%u\", "
-        "\"O\": \"%lf\", "
-        "\"x\": \"%lf\", "
-        "\"y\": \"%lf\""
+          "\"mode\": \"%u\", "
+          "\"pose_current\": "
+          "{"
+            "\"O\": \"%lf\", "
+            "\"x\": \"%lf\", "
+            "\"y\": \"%lf\""
+          "}, "
+          "\"pose_order\": "
+          "{"
+            "\"O\": \"%lf\", "
+            "\"x\": \"%lf\", "
+            "\"y\": \"%lf\""
+          "}"
         "}\n",
         ctrl_quadpid.control.current_mode,
         ctrl_quadpid.control.pose_current.O,
         ctrl_quadpid.control.pose_current.x,
-        ctrl_quadpid.control.pose_current.y
+        ctrl_quadpid.control.pose_current.y,
+        ctrl_quadpid.control.pose_order.O,
+        ctrl_quadpid.control.pose_order.x,
+        ctrl_quadpid.control.pose_order.y
     );
     return EXIT_SUCCESS;
 }

--- a/platforms/cortex/platform.c
+++ b/platforms/cortex/platform.c
@@ -42,6 +42,9 @@ static shell_command_linked_t current_shell_commands;
 shell_command_linked_t pf_shell_commands;
 static const char *pf_name = "platform";
 
+/* Shared memory key used to communicate with the simulator */
+int pf_shm_key = 0;
+
 void pf_push_shell_commands(shell_command_linked_t *shell_commands) {
     shell_commands->previous = current_shell_commands.current;
     memcpy(&current_shell_commands, shell_commands, sizeof(shell_command_linked_t));
@@ -67,6 +70,7 @@ void pf_init_shell_commands(shell_command_linked_t *shell_commands, const char *
     shell_commands->shell_commands[0] = cmd_help_json;
     shell_commands->shell_commands[1] = cmd_print_pose_current;
     shell_commands->shell_commands[2] = cmd_print_dyn_obstacles;
+    shell_commands->shell_commands[3] = cmd_set_shm_key;
 }
 
 void pf_add_shell_command(shell_command_linked_t *shell_commands, shell_command_t *command)
@@ -130,6 +134,19 @@ int pf_print_pose_current(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
+int pf_set_shm_key(int argc, char **argv)
+{
+    /* Check arguments */
+    if (argc != 2) {
+        puts("Bad number of arguments!");
+        return EXIT_FAILURE;
+    }
+
+    pf_shm_key = atoi(argv[1]);
+
+    return EXIT_SUCCESS;
+}
+
 shell_command_t cmd_exit_shell = {
     "exit", "Exit planner calibration",
     pf_exit_shell
@@ -148,6 +165,11 @@ shell_command_t cmd_print_pose_current = {
 shell_command_t cmd_print_dyn_obstacles = {
     "_dyn_obstacles", "Print dynamic obstacles",
     avoidance_print_dyn_obstacles
+};
+
+shell_command_t cmd_set_shm_key = {
+    "_set_shm_key", "Set shared memory key to communicate with simulator",
+    pf_set_shm_key
 };
 
 

--- a/robotics/avoidance.c
+++ b/robotics/avoidance.c
@@ -379,8 +379,12 @@ int avoidance_print_dyn_obstacles(int argc, char **argv)
 
     printf("[");
 
-    for(int i = nb_polygons ; i < nb_dyn_polygons ; i++) {
+    for(int i = nb_polygons ; i < nb_polygons + nb_dyn_polygons ; i++) {
         polygon_t *polygon = &(polygons[i]);
+
+        if(i > nb_polygons) {
+            printf(", ");
+        }
 
         printf("[");
         for(int j = 0 ; j < polygon->count ; j++) {


### PR DESCRIPTION
Use a shared memory array containing sensors values provided by the simulator.
Also add pose order info in output of "_pose" shell command.