### PR TITLE
Rename and improve shell command to get robot state

### DIFF
--- a/controllers/ctrl.c
+++ b/controllers/ctrl.c
@@ -127,21 +127,14 @@ void ctrl_register_speed_order_cb(ctrl_t *ctrl, speed_order_cb_t speed_order_cb)
     irq_enable();
 }
 
-polar_t ctrl_compute_speed_order(ctrl_t* ctrl)
+void ctrl_compute_speed_order(ctrl_t* ctrl)
 {
     speed_order_cb_t cb = ctrl->control.speed_order_cb;
-    polar_t speed_order = {0, 0};
 
     if (cb) {
         /* Variable speed_order is computable through a callback */
-        speed_order = (*cb)(ctrl);
+        ctrl->control.speed_order = (*cb)(ctrl);
     }
-    else {
-        /* Constant speed_order */
-        speed_order = ctrl->control.speed_order;
-    }
-
-    return speed_order;
 }
 
 void ctrl_set_mode(ctrl_t* ctrl, ctrl_mode_t new_mode)

--- a/controllers/include/ctrl.h
+++ b/controllers/include/ctrl.h
@@ -352,13 +352,11 @@ void ctrl_register_speed_order_cb(ctrl_t *ctrl, speed_order_cb_t speed_order_cb)
  * @brief compute speed order
  *
  * This function computes speed order by calling callback registered with
- * @ref ctrl_register_speed_order_cb.
+ * @ref ctrl_register_speed_order_cb and set the new speed order accordingly.
  *
  * @param[in] ctrl              Controller object
- *
- * @return                      Speed order
  */
-polar_t ctrl_compute_speed_order(ctrl_t* ctrl);
+void ctrl_compute_speed_order(ctrl_t* ctrl);
 
 /**
  * @brief Get current speed

--- a/controllers/quadpid/quadpid.c
+++ b/controllers/quadpid/quadpid.c
@@ -146,41 +146,41 @@ int ctrl_quadpid_stop(ctrl_t* ctrl, polar_t* command)
 
 int ctrl_quadpid_nopid(ctrl_t* ctrl, polar_t* command)
 {
-    polar_t speed_order;
+    /* Get speed order */
+    const polar_t* speed_order = ctrl_get_speed_order((ctrl_t*)ctrl);
 
-    ctrl_quadpid_t* ctrl_quadpid = (ctrl_quadpid_t*)ctrl;
+    /* Compute speed order */
+    ctrl_compute_speed_order((ctrl_t*)ctrl);
 
-    /* get speed order */
-    speed_order = ctrl_compute_speed_order((ctrl_t*)ctrl_quadpid);
-
-    command->distance = speed_order.distance;
-    command->angle = speed_order.angle;
+    command->distance = speed_order->distance;
+    command->angle = speed_order->angle;
 
     return 0;
 }
 
 int ctrl_quadpid_running_speed(ctrl_t* ctrl, polar_t* command)
 {
+    /* Get speed current */
     const polar_t* speed_current = ctrl_get_speed_current(ctrl);
+    /* Get speed order */
+    const polar_t* speed_order = ctrl_get_speed_order((ctrl_t*)ctrl);
 
-    ctrl_quadpid_t* ctrl_quadpid = (ctrl_quadpid_t*)ctrl;
+    /* Compute speed order */
+    ctrl_compute_speed_order((ctrl_t*)ctrl);
 
-    /* get speed order */
-    polar_t speed_order = ctrl_compute_speed_order((ctrl_t*)ctrl_quadpid);
-
-    command->distance = speed_order.distance;
-    command->angle = speed_order.angle;
+    command->distance = speed_order->distance;
+    command->angle = speed_order->angle;
 
     /* limit speed command->*/
     command->distance = limit_speed_command(command->distance,
-                                         fabs(speed_order.distance),
+                                         fabs(speed_order->distance),
                                          speed_current->distance);
     command->angle = limit_speed_command(command->angle,
-                                      fabs(speed_order.angle),
+                                      fabs(speed_order->angle),
                                       speed_current->angle);
 
     /* ********************** speed pid controller ********************* */
-    return ctrl_quadpid_speed(ctrl_quadpid, command, speed_current);
+    return ctrl_quadpid_speed((ctrl_quadpid_t*)ctrl, command, speed_current);
 }
 
 int ctrl_quadpid_ingame(ctrl_t* ctrl, polar_t* command)

--- a/platforms/cortex/include/platform.h
+++ b/platforms/cortex/include/platform.h
@@ -238,10 +238,10 @@ void pf_init_shell_commands(shell_command_linked_t *shell_commands, const char *
 void pf_add_shell_command(shell_command_linked_t *shell_commands, shell_command_t *command);
 int pf_display_json_help(int argc, char **argv);
 int pf_exit_shell(int argc, char **argv);
-int pf_print_pose_current_cb(int argc, char **argv);
+int pf_print_state_cb(int argc, char **argv);
 extern shell_command_t cmd_help_json;
 extern shell_command_t cmd_exit_shell;
-extern shell_command_t cmd_print_pose_current;
+extern shell_command_t cmd_print_state;
 extern shell_command_t cmd_print_dyn_obstacles;
 extern shell_command_t cmd_set_shm_key;
 

--- a/platforms/cortex/platform.c
+++ b/platforms/cortex/platform.c
@@ -67,7 +67,7 @@ void pf_init_shell_commands(shell_command_linked_t *shell_commands, const char *
         shell_commands->shell_commands[i] = (shell_command_t){ NULL, NULL, NULL };
     }
     shell_commands->shell_commands[0] = cmd_help_json;
-    shell_commands->shell_commands[1] = cmd_print_pose_current;
+    shell_commands->shell_commands[1] = cmd_print_state;
     shell_commands->shell_commands[2] = cmd_print_dyn_obstacles;
     shell_commands->shell_commands[3] = cmd_set_shm_key;
 }
@@ -113,7 +113,7 @@ int pf_exit_shell(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
-int pf_print_pose_current(int argc, char **argv)
+int pf_print_state(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -132,6 +132,17 @@ int pf_print_pose_current(int argc, char **argv)
             "\"O\": \"%lf\", "
             "\"x\": \"%lf\", "
             "\"y\": \"%lf\""
+          "}, "
+          "\"cycle\": \"%"PRIu32"\", "
+          "\"speed_current\": "
+          "{"
+            "\"distance\": \"%lf\", "
+            "\"angle\": \"%lf\""
+          "}, "
+          "\"speed_order\": "
+          "{"
+            "\"distance\": \"%lf\", "
+            "\"angle\": \"%lf\""
           "}"
         "}\n",
         ctrl_quadpid.control.current_mode,
@@ -140,8 +151,14 @@ int pf_print_pose_current(int argc, char **argv)
         ctrl_quadpid.control.pose_current.y,
         ctrl_quadpid.control.pose_order.O,
         ctrl_quadpid.control.pose_order.x,
-        ctrl_quadpid.control.pose_order.y
+        ctrl_quadpid.control.pose_order.y,
+        ctrl_quadpid.control.current_cycle,
+        ctrl_quadpid.control.speed_current.distance,
+        ctrl_quadpid.control.speed_current.angle,
+        ctrl_quadpid.control.speed_order.distance,
+        ctrl_quadpid.control.speed_order.angle
     );
+
     return EXIT_SUCCESS;
 }
 
@@ -168,9 +185,9 @@ shell_command_t cmd_help_json = {
     pf_display_json_help
 };
 
-shell_command_t cmd_print_pose_current = {
-    "_pose", "Print current pose",
-    pf_print_pose_current
+shell_command_t cmd_print_state = {
+    "_state", "Print current state",
+    pf_print_state
 };
 
 shell_command_t cmd_print_dyn_obstacles = {


### PR DESCRIPTION
Rename "_pose" shell command into "_state" as it prints more than positions.
Add cycle and speed info to "_state" command output.
Fix uint32_t printf format specifier.
