### PR TITLE
Fix fetch workflow

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,6 +26,7 @@ jobs:
         path: 'RIOT'
     - name: Install toolchain
       run: |
+        sudo apt-get update
         sudo apt-get install -qq build-essential gcc-multilib gcc-arm-none-eabi libnewlib-arm-none-eabi
         gcc --version
         arm-none-eabi-gcc --version


### PR DESCRIPTION
Fix 404 errors from `apt-get install`

Tested 5 times, worked 5 times, seems ok.