### PR TITLE
Add shell_menu module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -9,12 +9,23 @@ ifneq (,$(filter robotics,$(USEMODULE)))
 	DIRS += $(MCUFIRMWAREBASE)/robotics
 endif
 
-INCLUDES += -I$(APPDIR)/include/
+DIRS += $(MCUFIRMWAREBASE)/sys
+include $(MCUFIRMWAREBASE)/sys/Makefile.dep
+
+ifneq (, $(MCUFIRMWARE_PLATFORM_BASE))
+	INCLUDES += -I$(APPDIR)/include/
+	ifneq ($(CPU),native)
+		INCLUDES += -I$(APPDIR)/include/real/
+	else
+		INCLUDES += -I$(APPDIR)/include/simulation/
+	endif
+endif
 
 ifneq (,$(filter ctrl,$(USEMODULE)))
 	INCLUDES += -I$(MCUFIRMWAREBASE)/controllers/include/
 endif
 INCLUDES += -I$(MCUFIRMWAREBASE)/drivers/include/
+INCLUDES += -I$(MCUFIRMWAREBASE)/sys/include/
 ifneq (,$(filter planner,$(USEMODULE)))
 	INCLUDES += -I$(MCUFIRMWAREBASE)/planners/include/
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -26,10 +26,6 @@ ifneq ($(CPU),native)
 	.DEFAULT_GOAL := world
 	RAM_LEN_K := $(shell echo $(RAM_LEN) | sed 's/K//')
 	RAMSIZE := $(shell echo $$(( $(RAM_LEN_K) * $(KB) )) )
-
-	INCLUDES += -I$(APPDIR)/include/real/
-else
-	INCLUDES += -I$(APPDIR)/include/simulation/
 endif
 
 .PHONY: world

--- a/examples/shell_menu/Makefile
+++ b/examples/shell_menu/Makefile
@@ -1,0 +1,13 @@
+# name of your application
+APPLICATION = shell-menu
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+USEMODULE += shell_menu
+USEMODULE += ps
+
+include ../../Makefile.include

--- a/examples/shell_menu/main.c
+++ b/examples/shell_menu/main.c
@@ -1,0 +1,135 @@
+#include <stdio.h>
+
+#include "shell.h"
+#include "shell_menu.h"
+
+static int cmd_1_1(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 1 in sub-menu 1");
+
+    return 0;
+}
+
+static int cmd_1_2(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 2 in sub-menu 1");
+
+    return 0;
+}
+
+static int cmd_2_1(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 1 in sub-menu 2");
+
+    return 0;
+}
+
+static int cmd_2_2(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 2 in sub-menu 2");
+
+    return 0;
+}
+
+static int cmd_1(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 1 in main menu");
+
+    return 0;
+}
+
+static int cmd_2(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    puts("Execute command 2 in main menu");
+
+    return 0;
+}
+
+static int cmd_sub_1(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    shell_menu_t menu;
+    const shell_command_t commands[] = {
+        { "cmd_1_1", "Command 1/1", cmd_1_1 },
+        { "cmd_1_2", "Command 1/2", cmd_1_2 },
+        { NULL, NULL, NULL }
+    };
+
+    menu_init(&menu, "Sub-menu 1");
+
+    menu_add_list(&menu, commands);
+
+    menu_enter(&menu);
+
+    return 0;
+}
+
+static int cmd_sub_2(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    shell_menu_t menu;
+    const shell_command_t commands[] = {
+        { "cmd_2_1", "Command 2/1", cmd_2_1 },
+        { "cmd_2_2", "Command 2/2", cmd_2_2 },
+        { NULL, NULL, NULL }
+    };
+
+
+    menu_init(&menu, "Sub-menu 2");
+
+    menu_add_list(&menu, commands);
+
+    menu_enter(&menu);
+
+    return 0;
+}
+
+int main(void)
+{
+    puts("\n== Shell menu example ==");
+
+    /* Create the main menu */
+    shell_menu_t main_menu;
+
+    menu_init(&main_menu, "Main menu");
+
+    const shell_command_t main_menu_commands[] = {
+        { "cmd_1", "Command 1", cmd_1 },
+        { "cmd_2", "Command 2", cmd_2 },
+        { "sub1", "Enter sub-menu 1", cmd_sub_1 },
+        { "sub2", "Enter sub-menu 1", cmd_sub_2 },
+        menu_cmd_null
+    };
+
+    menu_add_list(&main_menu, main_menu_commands);
+
+    /* Push main menu */
+    menu_enter(&main_menu);
+
+    /* Start shell */
+    menu_start();
+
+    return 0;
+}

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,0 +1,3 @@
+DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1,0 +1,4 @@
+ifneq (,$(filter shell_menu,$(USEMODULE)))
+  USEMODULE += shell
+  USEMODULE += shell_commands
+endif

--- a/sys/include/shell_menu.h
+++ b/sys/include/shell_menu.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2021 COGIP Robotics association <cogip35@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_shell_menu Shell menu
+ * @ingroup     sys
+ * @brief       Menus for shell
+ *
+ * @{
+ *
+ * @file
+ * @brief       Shell menu interface definition
+ *
+ * @author      Eric Courtois <eric.courtois@gmail.com>
+ */
+
+#pragma once
+
+/* RIOT includes */
+#include "shell.h"
+
+/**
+ * @brief       Max shell commands
+ */
+#ifndef NB_SHELL_COMMANDS
+#  define NB_SHELL_COMMANDS 20
+#endif
+
+/**
+ * @brief       Typedef for shell_menu structure.
+ */
+typedef struct shell_menu shell_menu_t;
+
+/**
+ * @brief       Shell menu linked list element.
+ */
+struct shell_menu {
+    shell_command_t shell_commands[NB_SHELL_COMMANDS]; /**< Copy of the menu currently used */
+    shell_menu_t *current;  /**< Pointer to the real current shell_commands */
+    shell_menu_t *previous; /**< Pointer to the real previous shell_commands */
+    const char *name;       /**< Menu name */
+};
+
+/**
+ * @brief        Null command used to terminate a command list.
+ */
+extern const shell_command_t menu_cmd_null;
+
+/**
+ * @brief        Initialize a menu.
+ *
+ * @param[in]    menu      menu to initialize
+ * @param[in]    name      name of the menu
+ */
+void menu_init(shell_menu_t *menu, const char *name);
+
+/**
+ * @brief        Add a command to a menu.
+ *
+ * @param[in]    menu      menu
+ * @param[in]    command   command to add
+ */
+void menu_add_one(shell_menu_t *menu, const shell_command_t *command);
+
+/**
+ * @brief        Add a list of command to a menu.
+ *
+ * @param[in]    menu       menu
+ * @param[in]    commands   list of commands to add
+ */
+void menu_add_list(shell_menu_t *menu, const shell_command_t commands[]);
+
+/**
+ * @brief        Enter a new menu.
+ *
+ * @param[in]    menu       new menu
+ */
+void menu_enter(shell_menu_t *menu);
+
+/**
+ * @brief        Exit current menu and go back to previous menu.
+ */
+void menu_exit(void);
+
+/**
+ * @brief        Start the main menu.
+ */
+void menu_start(void);

--- a/sys/shell_menu/Makefile
+++ b/sys/shell_menu/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/shell_menu/shell_menu.c
+++ b/sys/shell_menu/shell_menu.c
@@ -1,0 +1,102 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shell_menu.h"
+
+const shell_command_t menu_cmd_null = {NULL, NULL, NULL};
+
+shell_menu_t current_menu;
+
+static int _display_json_help(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("{\"name\": \"%s\", \"entries\": [", current_menu.name);
+    shell_command_t *cmd = (shell_command_t*)&current_menu;
+    for (; cmd->name != NULL; cmd++) {
+        if(cmd != (shell_command_t*)&current_menu) {
+            printf(", ");
+        }
+        printf(
+            "{\"cmd\": \"%s\", \"desc\": \"%s\"}",
+            cmd->name,
+            cmd->desc
+        );
+    }
+    printf("]}\n");
+    return EXIT_SUCCESS;
+}
+
+static int _exit_menu(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    menu_exit();
+
+    return EXIT_SUCCESS;
+}
+
+const shell_command_t cmd_exit_menu = {
+    "exit", "Exit current menu",
+    _exit_menu
+};
+
+const shell_command_t cmd_help_json = {
+    "_help_json", "Display available commands in JSON format",
+    _display_json_help
+};
+
+void menu_init(shell_menu_t *menu, const char *name) {
+    menu->name = name;
+    menu->current = menu;
+    menu->previous = NULL;
+
+    for(uint8_t i = 0 ; i < NB_SHELL_COMMANDS ; i++) {
+        menu->shell_commands[i] = menu_cmd_null;
+    }
+
+    menu_add_one(menu, &cmd_exit_menu);
+    menu_add_one(menu, &cmd_help_json);
+}
+
+void menu_add_one(shell_menu_t *menu, const shell_command_t *command)
+{
+    uint8_t command_id = 0;
+
+    for (shell_command_t *cmd = menu->shell_commands ; cmd->name != NULL; cmd++, command_id++) {}
+
+    assert(command_id < NB_SHELL_COMMANDS);
+
+    menu->shell_commands[command_id++] = *command;
+}
+
+void menu_add_list(shell_menu_t *menu, const shell_command_t commands[])
+{
+    for (const shell_command_t *cmd = commands; cmd->name != NULL; cmd++) {
+        menu_add_one(menu, cmd);
+    }
+}
+
+void menu_enter(shell_menu_t *menu) {
+    menu->previous = current_menu.current;
+    memcpy(&current_menu, menu, sizeof(shell_menu_t));
+    printf("Enter shell menu: %s\n", menu->name);
+}
+
+void menu_exit(void) {
+    if (current_menu.previous) {
+        printf("Exit shell menu: %s\n", current_menu.name);
+        memcpy(&current_menu, current_menu.previous, sizeof(shell_menu_t));
+        printf("Enter shell menu: %s\n", current_menu.name);
+    }
+}
+
+void menu_start(void)
+{
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    shell_run((shell_command_t*)&current_menu, line_buf, SHELL_DEFAULT_BUFSIZE);
+}


### PR DESCRIPTION
Add a sys directory in mcu-firmware.
Add a first module shell_menu.
This module extends the shell module by providing an API
to declare sub-menus and navigate through them.

Also add an example directory to add example of modules usage.
