### PR TITLE
LDS01 DMA Driver: Add native support

### DIFF
--- a/drivers/lds01/include/lds01.h
+++ b/drivers/lds01/include/lds01.h
@@ -50,6 +50,7 @@ typedef void (*lds01_new_frame_cb_t)(void);         /**< new frame callback sign
 typedef struct {
     uart_t uart;                        /**< UART device */
     lds01_new_frame_cb_t new_frame_cb;  /**< function called when a new frame is available */
+    bool invert_data;                   /**< invert data (false by default) */
 } lds01_params_t;
 
 /**

--- a/drivers/lds01/include/lds01.h
+++ b/drivers/lds01/include/lds01.h
@@ -100,6 +100,14 @@ void lds01_stop(const lds01_t lds01);
 void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter);
 
 /**
+ * @brief Set new minimun intensity value used to validate distances
+ *
+ * @param[in]   lds01       lds01 device id
+ * @param[in]   new_filter  value of the new minimun intensity
+ */
+void lds01_set_min_intensity(const lds01_t lds01, uint16_t new_min_intensity);
+
+/**
  * @brief Get distance data
  *
  * @param[in]   lds01      lds01 device id

--- a/drivers/lds01/include/lds01_params.h
+++ b/drivers/lds01/include/lds01_params.h
@@ -34,7 +34,8 @@ extern "C" {
 static const lds01_params_t lds01_params[] = {
     {
         .uart = UART_DEV(2),
-        .new_frame_cb = NULL
+        .new_frame_cb = NULL,
+        .invert_data = false
     }
 };
 

--- a/drivers/lds01/lds01.c
+++ b/drivers/lds01/lds01.c
@@ -218,7 +218,14 @@ void lds01_get_distances(const lds01_t lds01, uint16_t *distances)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     mutex_lock(&lds01_dev->data_lock);
-    memcpy((void *)distances, (void *)lds01_dev->distances, LDS01_NB_ANGLES * sizeof(uint16_t));
+    if (lds01_dev->params.invert_data) {
+        for (uint16_t i = 0; i < LDS01_NB_ANGLES; i++) {
+            distances[i] = lds01_dev->distances[(LDS01_NB_ANGLES - i) % LDS01_NB_ANGLES];
+        }
+    }
+    else {
+        memcpy((void *)distances, (void *)lds01_dev->distances, LDS01_NB_ANGLES * sizeof(uint16_t));
+    }
     mutex_unlock(&lds01_dev->data_lock);
 }
 
@@ -229,6 +236,13 @@ void lds01_get_intensities(const lds01_t lds01, uint16_t *intensities)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     mutex_lock(&lds01_dev->data_lock);
-    memcpy((void *)intensities, (void *)lds01_dev->intensities, LDS01_NB_ANGLES * sizeof(uint16_t));
+    if (lds01_dev->params.invert_data) {
+        for (uint16_t i = 0; i < LDS01_NB_ANGLES; i++) {
+            intensities[i] = lds01_dev->intensities[(LDS01_NB_ANGLES - i) % LDS01_NB_ANGLES];
+        }
+    }
+    else {
+        memcpy((void *)intensities, (void *)lds01_dev->intensities, LDS01_NB_ANGLES * sizeof(uint16_t));
+    }
     mutex_unlock(&lds01_dev->data_lock);
 }

--- a/drivers/lds01/lds01.c
+++ b/drivers/lds01/lds01.c
@@ -42,6 +42,7 @@ typedef struct {
     lds01_params_t params;                  /**< parameters */
     bool running;                           /**< set to true if lds01 is running */
     uint16_t filter;                        /**< distance filter in millimeters */
+    uint16_t min_intensity;                 /**< minimum intensity to consider the data valid */
     mutex_t data_lock;                      /**< lock protecting data access */
     uint16_t distances[LDS01_NB_ANGLES];    /**< distance data */
     uint16_t intensities[LDS01_NB_ANGLES];  /**< intensity data */
@@ -101,7 +102,7 @@ static uint16_t lds01_get_filtered_distance(lds01_dev_t *lds01_dev, uint16_t dis
     if (lds01_dev->filter == 0) {
         return distance;
     }
-    if (intensity == 0 || distance == 0 || distance > lds01_dev->filter) {
+    if (intensity < lds01_dev->min_intensity || distance == 0 || distance > lds01_dev->filter) {
         return lds01_dev->filter;
     }
     return distance;
@@ -154,6 +155,7 @@ int lds01_init(const lds01_t lds01, const lds01_params_t *params)
 
     lds01_dev->params = *params;
     lds01_dev->filter = 0;
+    lds01_dev->min_intensity = 0;
     lds01_reset_data(lds01_dev);
     mutex_init(&lds01_dev->data_lock);
 
@@ -209,6 +211,15 @@ void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     lds01_dev->filter = new_filter;
+}
+
+void lds01_set_min_intensity(const lds01_t lds01, uint16_t new_min_intensity)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    lds01_dev->min_intensity = new_min_intensity;
 }
 
 void lds01_get_distances(const lds01_t lds01, uint16_t *distances)

--- a/drivers/lds01_dma/Makefile
+++ b/drivers/lds01_dma/Makefile
@@ -1,1 +1,7 @@
+ifeq ($(CPU),native)
+	SRC=lds01_native.c
+else
+	SRC=lds01.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/drivers/lds01_dma/Makefile.dep
+++ b/drivers/lds01_dma/Makefile.dep
@@ -1,2 +1,7 @@
+ifeq ($(CPU),native)
+	USEMODULE += shmem
+else
+	FEATURES_REQUIRED += periph_dma
+endif
+
 FEATURES_REQUIRED += periph_uart
-FEATURES_REQUIRED += periph_dma

--- a/drivers/lds01_dma/include/lds01.h
+++ b/drivers/lds01_dma/include/lds01.h
@@ -104,6 +104,14 @@ void lds01_stop(const lds01_t lds01);
 void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter);
 
 /**
+ * @brief Set new minimun intensity value used to validate distances
+ *
+ * @param[in]   lds01       lds01 device id
+ * @param[in]   new_filter  value of the new minimun intensity
+ */
+void lds01_set_min_intensity(const lds01_t lds01, uint16_t new_min_intensity);
+
+/**
  * @brief Get distance data
  *
  * @param[in]   lds01      lds01 device id

--- a/drivers/lds01_dma/include/lds01.h
+++ b/drivers/lds01_dma/include/lds01.h
@@ -54,6 +54,7 @@ typedef void (*lds01_new_frame_cb_t)(void);         /**< new frame callback sign
 typedef struct {
     uart_t uart;                        /**< UART device */
     lds01_new_frame_cb_t new_frame_cb;  /**< function called when a new frame is available */
+    bool invert_data;                   /**< invert data (false by default) */
 } lds01_params_t;
 
 /**

--- a/drivers/lds01_dma/include/lds01_params.h
+++ b/drivers/lds01_dma/include/lds01_params.h
@@ -36,7 +36,8 @@ extern "C" {
 static const lds01_params_t lds01_params[] = {
     {
         .uart = UART_DEV(2),
-        .new_frame_cb = NULL
+        .new_frame_cb = NULL,
+        .invert_data = false
     }
 };
 

--- a/drivers/lds01_dma/lds01.c
+++ b/drivers/lds01_dma/lds01.c
@@ -280,7 +280,14 @@ void lds01_get_distances(const lds01_t lds01, uint16_t *distances)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     mutex_lock(&lds01_dev->data_lock);
-    memcpy((void *)distances, (void *)lds01_dev->distances, LDS01_NB_ANGLES * sizeof(uint16_t));
+    if (lds01_dev->params.invert_data) {
+        for (uint16_t i = 0; i < LDS01_NB_ANGLES; i++) {
+            distances[i] = lds01_dev->distances[(LDS01_NB_ANGLES - i) % LDS01_NB_ANGLES];
+        }
+    }
+    else {
+        memcpy((void *)distances, (void *)lds01_dev->distances, LDS01_NB_ANGLES * sizeof(uint16_t));
+    }
     mutex_unlock(&lds01_dev->data_lock);
 }
 
@@ -291,6 +298,13 @@ void lds01_get_intensities(const lds01_t lds01, uint16_t *intensities)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     mutex_lock(&lds01_dev->data_lock);
-    memcpy((void *)intensities, (void *)lds01_dev->intensities, LDS01_NB_ANGLES * sizeof(uint16_t));
+    if (lds01_dev->params.invert_data) {
+        for (uint16_t i = 0; i < LDS01_NB_ANGLES; i++) {
+            intensities[i] = lds01_dev->intensities[(LDS01_NB_ANGLES - i) % LDS01_NB_ANGLES];
+        }
+    }
+    else {
+        memcpy((void *)intensities, (void *)lds01_dev->intensities, LDS01_NB_ANGLES * sizeof(uint16_t));
+    }
     mutex_unlock(&lds01_dev->data_lock);
 }

--- a/drivers/lds01_dma/lds01.c
+++ b/drivers/lds01_dma/lds01.c
@@ -50,6 +50,7 @@ typedef struct {
     lds01_params_t params;                      /**< parameters */
     bool running;                               /**< set to true if lds01 is running */
     uint16_t filter;                            /**< distance filter in millimeters */
+    uint16_t min_intensity;                     /**< minimum intensity to consider the data valid */
     mutex_t data_lock;                          /**< lock protecting data access */
     uint16_t distances[LDS01_NB_ANGLES];        /**< distance data */
     uint16_t intensities[LDS01_NB_ANGLES];      /**< intensity data */
@@ -120,7 +121,7 @@ static uint16_t lds01_get_filtered_distance(lds01_dev_t *lds01_dev, uint16_t dis
     if (lds01_dev->filter == 0) {
         return distance;
     }
-    if (intensity == 0 || distance == 0 || distance > lds01_dev->filter) {
+    if (intensity < lds01_dev->min_intensity || distance == 0 || distance > lds01_dev->filter) {
         return lds01_dev->filter;
     }
     return distance;
@@ -185,6 +186,7 @@ int lds01_init(const lds01_t lds01, const lds01_params_t *params)
 
     lds01_dev->params = *params;
     lds01_dev->filter = 0;
+    lds01_dev->min_intensity = 0;
     lds01_reset_data(lds01_dev);
     mutex_init(&lds01_dev->data_lock);
 
@@ -271,6 +273,15 @@ void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter)
     lds01_dev_t *lds01_dev = &lds01_devs[lds01];
 
     lds01_dev->filter = new_filter;
+}
+
+void lds01_set_min_intensity(const lds01_t lds01, uint16_t new_min_intensity)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    lds01_dev->min_intensity = new_min_intensity;
 }
 
 void lds01_get_distances(const lds01_t lds01, uint16_t *distances)

--- a/drivers/lds01_dma/lds01_native.c
+++ b/drivers/lds01_dma/lds01_native.c
@@ -105,7 +105,12 @@ void lds01_get_distances(const lds01_t lds01, uint16_t *distances)
     if (shared_data) {
         for (unsigned int i = 0; i < LDS01_NB_ANGLES; i++) {
             uint16_t distance = shared_data->lidar_distances[i];
-            lds01_dev->distances[i] = lds01_get_filtered_distance(lds01_dev, distance, 1);
+            if (lds01_dev->params.invert_data) {
+                lds01_dev->distances[(LDS01_NB_ANGLES - i) % LDS01_NB_ANGLES] = lds01_get_filtered_distance(lds01_dev, distance, 1);
+            }
+            else {
+                lds01_dev->distances[i] = lds01_get_filtered_distance(lds01_dev, distance, 1);
+            }
         }
     }
 

--- a/drivers/lds01_dma/lds01_native.c
+++ b/drivers/lds01_dma/lds01_native.c
@@ -1,0 +1,122 @@
+#include "lds01.h"
+#include "lds01_params.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#include <string.h>
+
+#include "shmem.h"
+
+const shmem_data_t *shared_data = NULL;
+
+#define LDS01_NUMOF ARRAY_SIZE(lds01_params)    /**< number of used lds01 devices */
+
+/**
+ * @brief   LDS01 native descriptor
+ */
+typedef struct {
+    lds01_params_t params;                      /**< parameters */
+    bool running;                               /**< set to true if lds01 is running */
+    uint16_t filter;                            /**< distance filter in millimeters */
+    uint16_t distances[LDS01_NB_ANGLES];        /**< distance data */
+    uint16_t intensities[LDS01_NB_ANGLES];      /**< intensity data */
+} lds01_dev_t;
+
+/* Allocate memory for the device descriptor */
+lds01_dev_t lds01_devs[LDS01_NUMOF];
+
+static uint16_t lds01_get_filtered_distance(lds01_dev_t *lds01_dev, uint16_t distance, uint16_t intensity)
+{
+    if (lds01_dev->filter == 0) {
+        return distance;
+    }
+    if (intensity == 0 || distance == 0 || distance > lds01_dev->filter) {
+        return lds01_dev->filter;
+    }
+    return distance;
+}
+
+void lds01_update_last_frame(const lds01_t lds01)
+{
+    assert(lds01 < LDS01_NUMOF);
+}
+
+int lds01_init(const lds01_t lds01, const lds01_params_t *params)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    lds01_dev->params = *params;
+    lds01_dev->filter = 0;
+    lds01_dev->running = false;
+
+    for (unsigned int i = 0; i < LDS01_NB_ANGLES; i++) {
+        lds01_dev->distances[i] = 0;
+        lds01_dev->intensities[i] = 1000;
+    }
+
+    DEBUG("LDS01 native initialized\n");
+
+    return 0;
+}
+
+void lds01_start(const lds01_t lds01)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    if (lds01_dev->running) {
+        return;
+    }
+    lds01_dev->running = true;
+}
+
+void lds01_stop(const lds01_t lds01)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    lds01_dev->running = false;
+}
+
+void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    lds01_dev->filter = new_filter;
+}
+
+void lds01_get_distances(const lds01_t lds01, uint16_t *distances)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    if (shared_data == NULL) {
+        shared_data = shmem_get_data();
+    }
+
+    if (shared_data) {
+        for (unsigned int i = 0; i < LDS01_NB_ANGLES; i++) {
+            uint16_t distance = shared_data->lidar_distances[i];
+            lds01_dev->distances[i] = lds01_get_filtered_distance(lds01_dev, distance, 1);
+        }
+    }
+
+    memcpy((void *)distances, (void *)lds01_dev->distances, LDS01_NB_ANGLES * sizeof(uint16_t));
+}
+
+void lds01_get_intensities(const lds01_t lds01, uint16_t *intensities)
+{
+    assert(lds01 < LDS01_NUMOF);
+
+    lds01_dev_t *lds01_dev = &lds01_devs[lds01];
+
+    memcpy((void *)intensities, (void *)lds01_dev->intensities, LDS01_NB_ANGLES * sizeof(uint16_t));
+}

--- a/drivers/lds01_dma/lds01_native.c
+++ b/drivers/lds01_dma/lds01_native.c
@@ -92,6 +92,12 @@ void lds01_set_distance_filter(const lds01_t lds01, uint16_t new_filter)
     lds01_dev->filter = new_filter;
 }
 
+void lds01_set_min_intensity(const lds01_t lds01, uint16_t new_min_intensity)
+{
+    (void)new_min_intensity;
+    assert(lds01 < LDS01_NUMOF);
+}
+
 void lds01_get_distances(const lds01_t lds01, uint16_t *distances)
 {
     assert(lds01 < LDS01_NUMOF);

--- a/examples/lds01/include/lds01_params.h
+++ b/examples/lds01/include/lds01_params.h
@@ -35,7 +35,8 @@ extern void new_frame_available_cb(void);
 static const lds01_params_t lds01_params[] = {
     {
         .uart = UART_DEV(2),
-        .new_frame_cb = new_frame_available_cb
+        .new_frame_cb = new_frame_available_cb,
+        .invert_data = false
     }
 };
 

--- a/examples/lds01_dma/include/lds01_params.h
+++ b/examples/lds01_dma/include/lds01_params.h
@@ -32,7 +32,8 @@ extern void new_frame_available_cb(void);
 static const lds01_params_t lds01_params[] = {
     {
         .uart = UART_DEV(2),
-        .new_frame_cb = new_frame_available_cb
+        .new_frame_cb = new_frame_available_cb,
+        .invert_data = false
     }
 };
 

--- a/examples/lds01_dma/include/shmem_params.h
+++ b/examples/lds01_dma/include/shmem_params.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2021 COGIP Robotics association <cogip35@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Parameters for shmem
+ *
+ * @author      Eric Courtois <eric.courtois@gmail.com>
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "lds01.h"
+
+/* SHM structure representing the memory shared with the simulator */
+typedef struct {
+    uint16_t lidar_distances[LDS01_NB_ANGLES];
+} shmem_data_t;

--- a/examples/lds01_dma/main.c
+++ b/examples/lds01_dma/main.c
@@ -9,6 +9,10 @@
 #include "lds01.h"
 #include "lds01_params.h"
 
+#ifdef MODULE_SHMEM
+#include "shmem.h"
+#endif
+
 /* Device to use (defined in lds01_params.h) */
 lds01_t lds01 = 0;
 
@@ -165,6 +169,9 @@ static const shell_command_t shell_commands[] = {
     { "stop", "Stop LDS01 device", cmd_stop },
     { "filter", "Set the filter value (max distance)", cmd_set_distance_filter },
     { "data", "Print current values", cmd_data },
+#ifdef MODULE_SHMEM
+    SHMEM_SET_KEY_CMD,
+#endif
     { NULL, NULL, NULL }
 };
 


### PR DESCRIPTION
Support native compilation of lds01_dma driver.
Data can be updated using shared memory is configured.

Add the possibility to invert distance and intensity data.

Add configuration of the minimum intensity required to validate a distance.