### PR TITLE
Path as module

### DIFF
--- a/applications/app_test/path.c
+++ b/applications/app_test/path.c
@@ -1,4 +1,5 @@
 #include <stddef.h>
+#include <kernel_defines.h>
 
 #include "path.h"
 #include "platform.h"
@@ -47,74 +48,6 @@ path_t robot_path = {
     /* static cfg */
     .current_pose_idx = 0,
     .play_in_loop = TRUE,
-    .nb_pose = sizeof(poses) / sizeof(path_pose_t),
+    .nb_poses = ARRAY_SIZE(poses),
     .poses = poses,
 };
-
-inline const path_pose_t *path_get_current_path_pos(const path_t *path)
-{
-    return &path->poses[path->current_pose_idx];
-}
-
-inline const path_pose_t *path_get_pose_at_idx(path_t *path, uint8_t idx)
-{
-    if ((idx < path->nb_pose) && (idx > 0)) {
-        return &path->poses[idx];
-    }
-    else {
-        return NULL;
-    }
-}
-
-inline uint8_t path_get_current_pose_idx(path_t *path)
-{
-    return path->current_pose_idx;
-}
-
-inline void path_set_current_pose_idx(path_t *path, uint8_t idx)
-{
-    path->current_pose_idx = idx;
-}
-
-inline void path_reset_current_pose_idx(path_t *path)
-{
-    path->current_pose_idx = 0;
-}
-
-inline void path_increment_current_pose_idx(path_t *path)
-{
-    if (path->current_pose_idx < path->nb_pose - 1) {
-        path->current_pose_idx += 1;
-    }
-    else if (path->play_in_loop) {
-        path->current_pose_idx = 0;
-    }
-}
-
-inline void path_decrement_current_pose_idx(path_t *path)
-{
-    if (path->current_pose_idx > 0) {
-        path->current_pose_idx -= 1;
-    }
-    else if (path->play_in_loop) {
-        path->current_pose_idx = path->nb_pose - 1;
-    }
-}
-
-inline uint8_t path_get_current_max_speed(const path_t *path)
-{
-    const path_pose_t *current_path_pos = &path->poses[path->current_pose_idx];
-
-    return MIN(current_path_pos->max_speed, MAX_SPEED);
-}
-
-void path_horizontal_mirror_all_pos(const path_t *path)
-{
-    for (int i = 0; i < path->nb_pose; i++) {
-        pose_t *pos = (pose_t *)&path->poses[i].pos;
-
-        pos->x *= -1;
-        pos->O = 180 - pos->O;
-        pos->O = ((int)pos->O) % 360;
-    }
-}

--- a/applications/cup2019/path.c
+++ b/applications/cup2019/path.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <kernel_defines.h>
 
 #include "path.h"
 #include "app.h"
@@ -370,74 +371,6 @@ path_t robot_path = {
     /* static cfg */
     .current_pose_idx = 0,
     .play_in_loop = FALSE,
-    .nb_pose = sizeof(poses) / sizeof(path_pose_t),
+    .nb_poses = ARRAY_SIZE(poses),
     .poses = poses,
 };
-
-inline const path_pose_t *path_get_current_path_pos(const path_t *path)
-{
-    return &path->poses[path->current_pose_idx];
-}
-
-inline const path_pose_t *path_get_pose_at_idx(path_t *path, uint8_t idx)
-{
-    if ((idx < path->nb_pose) && (idx > 0)) {
-        return &path->poses[idx];
-    }
-    else {
-        return NULL;
-    }
-}
-
-inline uint8_t path_get_current_pose_idx(path_t *path)
-{
-    return path->current_pose_idx;
-}
-
-inline void path_set_current_pose_idx(path_t *path, uint8_t idx)
-{
-    path->current_pose_idx = idx;
-}
-
-inline void path_reset_current_pose_idx(path_t *path)
-{
-    path->current_pose_idx = 0;
-}
-
-inline void path_increment_current_pose_idx(path_t *path)
-{
-    if (path->current_pose_idx < path->nb_pose - 1) {
-        path->current_pose_idx += 1;
-    }
-    else if (path->play_in_loop) {
-        path->current_pose_idx = 0;
-    }
-}
-
-inline void path_decrement_current_pose_idx(path_t *path)
-{
-    if (path->current_pose_idx > 0) {
-        path->current_pose_idx -= 1;
-    }
-    else if (path->play_in_loop) {
-        path->current_pose_idx = path->nb_pose - 1;
-    }
-}
-
-inline uint8_t path_get_current_max_speed(const path_t *path)
-{
-    const path_pose_t *current_path_pos = &path->poses[path->current_pose_idx];
-
-    return MIN(current_path_pos->max_speed, MAX_SPEED);
-}
-
-void path_horizontal_mirror_all_pos(const path_t *path)
-{
-    for (int i = 0; i < path->nb_pose; i++) {
-        pose_t *pos = (pose_t *)&path->poses[i].pos;
-
-        pos->x *= -1;
-        pos->O = 180 - pos->O;
-        pos->O = ((int)pos->O) % 360;
-    }
-}

--- a/lib/path/include/path.h
+++ b/lib/path/include/path.h
@@ -1,8 +1,36 @@
+/*
+ * Copyright (C) 2021 COGIP Robotics association <cogip35@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    lib_path Containing Path structure definition and utility functions to work with path
+ * @ingroup     lib
+ * @brief       Path module
+ *
+ *
+ * @{
+ * @file
+ * @brief       Public API for path module
+ *
+ * @author      Stephen Clymans <sclymans@gmail.com>
+ */
 #pragma once
 
+/* Project includes */
 #include "utils.h"
 #include "odometry.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Position type as used in path type
+ */
 typedef struct {
     pose_t pos;
     uint8_t allow_reverse;
@@ -10,25 +38,64 @@ typedef struct {
     func_cb_t act;
 } path_pose_t;
 
+/**
+ * @brief Path type
+ */
 typedef struct {
     /* static cfg */
     uint8_t play_in_loop; /* for unit tests */
-    uint8_t nb_pose;
+    uint8_t nb_poses;
     const path_pose_t *poses;
 
     /* dynamic variables */
     uint8_t current_pose_idx;
 } path_t;
 
-
+/**
+ * @brief Global variable containing complete robot path
+ */
 extern path_t robot_path;
 
-const path_pose_t *path_get_current_path_pos(const path_t *path);
-const path_pose_t *path_get_pose_at_idx(path_t *path, uint8_t idx);
-uint8_t path_get_current_pose_idx(path_t *path);
-void path_set_current_pose_idx(path_t *path, uint8_t idx);
+/**
+ * @brief Get current position
+ * @param[in]    path    robot path
+ * @return               current position of the path
+ */
+const path_pose_t *path_get_current_pose(const path_t *path);
+
+/**
+ * @brief Reset current position to index 0
+ * @param[out]    path    robot path
+ */
 void path_reset_current_pose_idx(path_t *path);
+
+/**
+ * @brief Increment the current position in the robot path (going forward to the next position)
+ * @param[out]    path    robot path
+ */
 void path_increment_current_pose_idx(path_t *path);
+
+/**
+ * @brief Decrement the current position in the robot path (going back to the last position)
+ * @param[out]    path    robot path
+ */
 void path_decrement_current_pose_idx(path_t *path);
+
+/**
+ * @brief Get maximum speed to use in order to go to the current position
+ * @param[out]    path    robot path
+ * @return               maximum speed to use to go to the current position
+ */
 uint8_t path_get_current_max_speed(const path_t *path);
-void path_horizontal_mirror_all_pos(const path_t *path);
+
+/**
+ * @brief Mirror all points in path to match the two possible sides of the game
+ * @param[out]    path    robot path
+ */
+void path_horizontal_mirror_all_poses(const path_t *path);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */

--- a/lib/path/path.c
+++ b/lib/path/path.c
@@ -1,0 +1,52 @@
+#include "path.h"
+
+#include "platform.h"
+#include "utils.h"
+
+inline const path_pose_t *path_get_current_pose(const path_t *path)
+{
+    return &path->poses[path->current_pose_idx];
+}
+
+inline void path_reset_current_pose_idx(path_t *path)
+{
+    path->current_pose_idx = 0;
+}
+
+inline void path_increment_current_pose_idx(path_t *path)
+{
+    if (path->current_pose_idx < path->nb_poses - 1) {
+        path->current_pose_idx += 1;
+    }
+    else if (path->play_in_loop) {
+        path->current_pose_idx = 0;
+    }
+}
+
+inline void path_decrement_current_pose_idx(path_t *path)
+{
+    if (path->current_pose_idx > 0) {
+        path->current_pose_idx -= 1;
+    }
+    else if (path->play_in_loop) {
+        path->current_pose_idx = path->nb_poses - 1;
+    }
+}
+
+inline uint8_t path_get_current_max_speed(const path_t *path)
+{
+    const path_pose_t *current_path_pos = &path->poses[path->current_pose_idx];
+
+    return MIN(current_path_pos->max_speed, MAX_SPEED);
+}
+
+void path_horizontal_mirror_all_poses(const path_t *path)
+{
+    for (int i = 0; i < path->nb_poses; i++) {
+        pose_t *pos = (pose_t *)&path->poses[i].pos;
+
+        pos->x *= -1;
+        pos->O = 180 - pos->O;
+        pos->O = ((int)pos->O) % 360;
+    }
+}

--- a/planners/astar/planner.c
+++ b/planners/astar/planner.c
@@ -54,7 +54,7 @@ static int trajectory_get_route_update(ctrl_t *ctrl, const pose_t *robot_pose,
                                        path_t *path)
 {
     /* Current final path pose to reach */
-    const path_pose_t *current_path_pos = path_get_current_path_pos(path);
+    const path_pose_t *current_path_pos = path_get_current_pose(path);
     /* Pose to reach by the controller */
     pose_t pose_to_reach = ctrl_get_pose_to_reach(ctrl);
     /* Avoidance graph position index. This index increments on each
@@ -90,7 +90,7 @@ static int trajectory_get_route_update(ctrl_t *ctrl, const pose_t *robot_pose,
                 path_increment_current_pose_idx(path);
             }
             /* Update current path targeted position in case it has changed */
-            current_path_pos = path_get_current_path_pos(path);
+            current_path_pos = path_get_current_pose(path);
 
             /* As current path pose could have changed, avoidance graph needs
              * to be recomputed */
@@ -98,7 +98,7 @@ static int trajectory_get_route_update(ctrl_t *ctrl, const pose_t *robot_pose,
         }
         else if ((!allow_change_path_pose) && (!ctrl_is_pose_intermediate(ctrl))) {
             /* Update current path targeted position in case it has changed */
-            current_path_pos = path_get_current_path_pos(path);
+            current_path_pos = path_get_current_pose(path);
             avoidance_update = TRUE;
         }
         /* If it is an intermediate pose, just go to the next one in
@@ -117,7 +117,7 @@ static int trajectory_get_route_update(ctrl_t *ctrl, const pose_t *robot_pose,
         }
         /* Increment the position to reach in the path */
         path_increment_current_pose_idx(path);
-        current_path_pos = path_get_current_path_pos(path);
+        current_path_pos = path_get_current_pose(path);
         /* As current path pose has changed, avoidance graph needs to be
          * recomputed */
         avoidance_update = TRUE;
@@ -137,17 +137,17 @@ static int trajectory_get_route_update(ctrl_t *ctrl, const pose_t *robot_pose,
         /* In case the targeted position is not reachable, select the
          * next position in the path. If no position is reachable, return an
          * error */
-        nb_pose_reachable = path->nb_pose;
+        nb_pose_reachable = path->nb_poses;
         while ((avoidance_index < 0) && (nb_pose_reachable-- > 0)) {
             if (avoidance_index == -1) {
                 if (!allow_change_path_pose) {
                     goto trajectory_get_route_update_error;
                 }
                 path_increment_current_pose_idx(path);
-                if (current_path_pos == path_get_current_path_pos(path)) {
+                if (current_path_pos == path_get_current_pose(path)) {
                     goto trajectory_get_route_update_error;
                 }
-                current_path_pos = path_get_current_path_pos(path);
+                current_path_pos = path_get_current_pose(path);
                 avoidance_index = update_graph(robot_pose, &(current_path_pos->pos));
             }
         }
@@ -199,7 +199,7 @@ void *task_planner(void *arg)
 
     /* object context initialisation */
     path->current_pose_idx = 0;
-    current_path_pos = path_get_current_path_pos(path);
+    current_path_pos = path_get_current_pose(path);
     initial_pose = current_path_pos->pos;
     ctrl_set_pose_current(ctrl, &initial_pose);
     ctrl_set_speed_order(ctrl, speed_order);
@@ -214,7 +214,7 @@ void *task_planner(void *arg)
             goto yield_point;
         }
 
-        current_path_pos = path_get_current_path_pos(path);
+        current_path_pos = path_get_current_pose(path);
 
         /* Update speed order to max speed defined value in the new point to reach */
         speed_order.distance = path_get_current_max_speed(path);

--- a/planners/shell_planners/shell_planners.c
+++ b/planners/shell_planners/shell_planners.c
@@ -57,7 +57,7 @@ static int pln_cmd_launch_action_cb(int argc, char **argv)
     (void)argv;
 
     path_t *path = pf_get_path();
-    const path_pose_t *current_path_pos = path_get_current_path_pos(path);
+    const path_pose_t *current_path_pos = path_get_current_pose(path);
 
     if (current_path_pos->act) {
         puts("Launch callback!");

--- a/platforms/cortex/platform.c
+++ b/platforms/cortex/platform.c
@@ -337,7 +337,7 @@ void pf_init(void)
 
     /* mirror the points in place if selected camp is left */
     if (pf_is_camp_left()) {
-        path_horizontal_mirror_all_pos(path);
+        path_horizontal_mirror_all_poses(path);
     }
 
     /* Initialize planner */


### PR DESCRIPTION
Define Path as a module and cleanup unused functions

tested in simulation for both _cup2019_ and _app_test_ targets.