### PR TITLE
Add UART and Protobuf Example

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install toolchain
       run: |
         sudo apt-get update
-        sudo apt-get install -qq build-essential gcc-multilib g++-multilib gcc-arm-none-eabi libnewlib-arm-none-eabi uncrustify
+        sudo apt-get install -qq build-essential gcc-multilib g++-multilib gcc-arm-none-eabi libnewlib-arm-none-eabi uncrustify protobuf-compiler
         gcc --version
         arm-none-eabi-gcc --version
     - name: Compile

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Makefile.local
 
 # Python compiled files
 *.pyc
+__pycache__
 
 # Ignore download cache
 .dlcache
@@ -62,3 +63,6 @@ scan-build/
 # Symbolic links
 pkg/*
 !pkg/vl53l0x-api
+
+# Protobuf generated files
+*_pb2.py

--- a/boards/cogip-nucleo-f446re/include/periph_conf.h
+++ b/boards/cogip-nucleo-f446re/include/periph_conf.h
@@ -81,14 +81,14 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev = USART1,
-        .rcc_mask = RCC_APB2ENR_USART1EN,
-        .rx_pin = GPIO_PIN(PORT_A, 10),
-        .tx_pin = GPIO_PIN(PORT_A, 9),
-        .rx_af = GPIO_AF7,
-        .tx_af = GPIO_AF7,
-        .bus = APB2,
-        .irqn = USART1_IRQn,
+        .dev = UART4,
+        .rcc_mask = RCC_APB1ENR_UART4EN,
+        .rx_pin = GPIO_PIN(PORT_A, 1),
+        .tx_pin = GPIO_PIN(PORT_A, 0),
+        .rx_af = GPIO_AF8,
+        .tx_af = GPIO_AF8,
+        .bus = APB1,
+        .irqn = UART4_IRQn,
 #ifdef MODULE_PERIPH_DMA
         .dma = DMA_STREAM_UNDEF,
         .dma_chan = UINT8_MAX,
@@ -111,7 +111,7 @@ static const uart_conf_t uart_config[] = {
 };
 
 #define UART_0_ISR          (isr_usart2)
-#define UART_1_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_uart4)
 #define UART_2_ISR          (isr_usart3)
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)

--- a/examples/uart-nanopb/Makefile
+++ b/examples/uart-nanopb/Makefile
@@ -1,0 +1,18 @@
+APPLICATION = uart-nanopb
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= cogip-nucleo-f446re
+#BOARD ?= cogip-native
+
+ifeq (native,$(findstring native,$(BOARD)))
+	CFLAGS += "-DUART_NUMOF=2"
+endif
+
+FEATURES_REQUIRED += periph_uart
+
+USEMODULE += shell_menu
+USEMODULE += ps
+
+USEPKG += nanopb
+
+include ../../Makefile.include

--- a/examples/uart-nanopb/README.md
+++ b/examples/uart-nanopb/README.md
@@ -1,0 +1,118 @@
+# Overview
+
+This example illustrates the usage of a second UART to communicate with another device
+using protobuf messages.
+
+In the Cogip context, the STM32 embedded in the robot will communicate with another device
+also embedded in the robot, like a Raspberry Pi or an Odroid (we will call it RPi).
+
+For testing, the RPi can be replaced by our development PC connected to the STM32
+using a USB-Serial adapter. In native mode, RPI is also replaced by the development platform.
+
+The software running on the RPi is written in Python.
+
+On the STM32 side, the example provides a command `hello` that sends a `ReqHello` message
+to the RPi.
+
+Two other commands `start` and `stop` to activate/deactivate a thread sending alternatively
+a `ReqPing` and a `ReqPong` message to the RPi.
+
+On the RPi side, the Python software will respond to `Req*` messages by `Ack*` messages.
+
+# Setup
+
+## Debian Requirements on Development Platform
+
+In addition to RIOT development environment, we need the following package:
+
+```sh
+$ sudo apt install protobuf-compiler
+```
+
+## Python Requirements on RPi
+
+Create a venv and install required packages inside:
+
+```sh
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
+## Generate Protobuf Messages Python Definitions
+
+```sh
+$ protoc --python_out=. pingpong.proto
+```
+
+# Compiling and Running Example on Real Hardware
+
+Use the `cogip-nucleo-f446re` board which defines a second UART on UART4.
+
+## Compilation and Flash STM32
+
+```sh
+$ make -j4 BOARD=cogip-nucleo-f446re flash
+```
+
+## Run Software on RPi
+
+```sh
+$ python uart-nanopb.py
+```
+
+It uses default serial port and baud rate if not specified on command line, see help for more info:
+
+```
+$ python uart-nanobp.py --help
+Usage: uart-nanobp.py [OPTIONS] [PORT] [BAUD]
+
+Arguments:
+  [PORT]  Serial port connected to STM32 device  [default: /dev/ttyUSB0]
+  [BAUD]  Baud rate  [default: 230400]
+
+Options:
+  --install-completion [bash|zsh|fish|powershell|pwsh]
+                                  Install completion for the specified shell.
+  --show-completion [bash|zsh|fish|powershell|pwsh]
+                                  Show completion for the specified shell, to
+                                  copy it or customize the installation.
+
+  --help                          Show this message and exit.
+```
+
+# Compiling and Running Example on Native Board
+
+Use the `cogip-native` board which allows using a second UART.
+
+## Create Virtual Serial Ports
+
+Make sure `socat`is install:
+
+```sh
+$ sudo apt install socat
+```
+
+Create the virtual ports in a different terminal:
+
+```sh
+$ socat -d -d pty,raw,echo=0,link=/tmp/ttySTM32 pty,raw,echo=0,link=/tmp/ttyRPI
+```
+
+
+## Compilation and Run the Native Firmware
+
+```sh
+$ make -j4 BOARD=cogip-native
+$ make BOARD=cogip-native PORT="-c /tmp -c /tmp/ttySTM32" term
+```
+
+Note: the first `-c` option is not used since the first UART is used for stdout.
+
+## Run Python Software
+
+In a different terminal:
+
+```sh
+$ python uart-nanopb.py /tmp/ttyRPI
+```

--- a/examples/uart-nanopb/colors.inc
+++ b/examples/uart-nanopb/colors.inc
@@ -1,0 +1,8 @@
+#ifndef COLOR_MACRO
+#  error COLOR_MACRO must be defined before including this file
+#endif
+
+COLOR_MACRO(NONE , 0)
+COLOR_MACRO(RED  , 1)
+COLOR_MACRO(GREEN, 2)
+COLOR_MACRO(BLUE , 3)

--- a/examples/uart-nanopb/main.cpp
+++ b/examples/uart-nanopb/main.cpp
@@ -1,0 +1,301 @@
+// RIOT includes
+#include "periph/uart.h"
+#include "ringbuffer.h"
+#include "riot/chrono.hpp"
+#include "riot/thread.hpp"
+#include "thread.h"
+#include "xtimer.h"
+
+// Projet includes
+#include "shell_menu/shell_menu.hpp"
+
+#include <pb_encode.h>
+#include <pb_decode.h>
+#include "pingpong.pb.h"
+
+#define READER_PRIO        (THREAD_PRIORITY_MAIN - 1)
+#define SENDER_PRIO        (THREAD_PRIORITY_MAIN - 1)
+
+static kernel_pid_t reader_pid, sender_pid;
+static char reader_stack[THREAD_STACKSIZE_MAIN];
+static char sender_stack[THREAD_STACKSIZE_MAIN];
+uart_t uart_dev = UART_DEV(1);
+uint32_t uart_speed = 230400U;
+bool suspend_sender = false;
+
+typedef struct {
+    char rx_mem[PB_Response_size];
+    ringbuffer_t rx_buf;
+} uart_ctx_t;
+
+static uart_ctx_t ctx;
+
+static uint8_t msg_length_bytes_number = 4;
+static uint8_t msg_length_bytes_received = 0;
+static uint32_t msg_length = 0;
+static uint32_t msg_bytes_received = 0;
+static uint8_t input_buffer[PB_Response_size];
+static uint8_t output_buffer[PB_Request_size];
+
+// C++ types corresponding to Protobuf message types
+class Pose {
+public:
+    Pose(double x=0.0, double y=0.0, double angle=0.0) : x(x), y(y), angle(angle) {};
+    Pose(const PB_Pose &pose) : x(pose.x), y(pose.y), angle(pose.angle) {};
+
+    void pb_copy(PB_Pose &pose) const {
+        pose.x = x;
+        pose.y = y;
+        pose.angle = angle;
+    }
+
+    double x;
+    double y;
+    double angle;
+};
+
+enum class Color {
+#define COLOR_MACRO(name, value) name = value,
+#include "colors.inc"
+#undef COLOR_MACRO
+};
+
+const char * const color_name[] = {
+#define COLOR_MACRO(name, value) #name,
+#include "colors.inc"
+#undef COLOR_MACRO
+};
+
+static void uart_rx_cb(void *arg, uint8_t data)
+{
+    (void)arg;
+    if (msg_length_bytes_received < msg_length_bytes_number) {
+        ((uint8_t *)&msg_length)[msg_length_bytes_received++] = data;
+        msg_bytes_received = 0;
+        return;
+    }
+
+    if (msg_bytes_received < msg_length) {
+        ringbuffer_add_one(&(ctx.rx_buf), data);
+        msg_bytes_received++;
+    }
+
+    if (msg_bytes_received == msg_length) {
+        msg_t msg;
+        msg.content.value = msg_length;
+        msg_send(&msg, reader_pid);
+        msg_length_bytes_received = 0;
+    }
+}
+
+void handle_response_hello(const PB_RespHello &hello)
+{
+    printf("<<== Hello response with number=%" PRId32 "\n\n", hello.number);
+}
+
+void handle_response_ping(const PB_RespPing &ping)
+{
+    printf("<<== Ping response with color=%s\n\n", color_name[ping.color]);
+}
+
+void handle_response_pong(const PB_RespPong &pong)
+{
+    Pose pose(pong.new_pose);
+    printf(
+        "<<== Pong response with pose={x=%.2lf, y=%.2lf, angle=%.2lf}\n\n",
+        pose.x, pose.y, pose.angle
+        );
+}
+
+static bool decode_message(uint32_t message_length, uint8_t *buffer)
+{
+    PB_Response response = PB_Response_init_zero;
+    pb_istream_t stream = pb_istream_from_buffer(buffer, message_length);
+    bool status = pb_decode(&stream, PB_Response_fields, &response);
+
+    if (!status)
+    {
+        printf("Decoding failed: %s\n", PB_GET_ERROR(&stream));
+        return false;
+    }
+
+    switch (response.which_response) {
+        case PB_Response_hello_tag:
+            handle_response_hello(response.response.hello);
+            break;
+        case PB_Response_ping_tag:
+            handle_response_ping(response.response.ping);
+            break;
+        case PB_Response_pong_tag:
+            handle_response_pong(response.response.pong);
+            break;
+        default:
+            printf("Unknown request type: %d\n", response.which_response);
+    }
+    return true;
+}
+
+static void *message_reader(void *arg)
+{
+    (void)arg;
+    msg_t msg;
+    msg_t msg_queue[8];
+    msg_init_queue(msg_queue, 8);
+
+    while (1) {
+        msg_receive(&msg);
+        uint32_t message_length = (uint32_t)msg.content.value;
+        ringbuffer_get(&(ctx.rx_buf), (char *)input_buffer, message_length);
+        decode_message(message_length, input_buffer);
+    }
+
+    return NULL;
+}
+
+static void send_message(size_t message_length, uint8_t *message)
+{
+    uart_write(uart_dev, (uint8_t *)&message_length, 4);
+    uart_write(uart_dev, message, message_length);
+}
+
+static bool send_request(const PB_Request &request)
+{
+    pb_ostream_t stream = pb_ostream_from_buffer(output_buffer, PB_Request_size);
+    bool status = pb_encode(&stream, PB_Request_fields, &request);
+
+    if (!status)
+    {
+        printf("Encoding failed: %s\n", PB_GET_ERROR(&stream));
+        return false;
+    }
+
+    send_message(stream.bytes_written, output_buffer);
+    return true;
+}
+
+static bool send_hello()
+{
+    PB_Request request = PB_Request_init_zero;
+    request.which_request = PB_Request_hello_tag;
+    PB_ReqHello &hello = request.request.hello;
+    hello.number = std::rand();
+
+    printf("==>> Hello request  with number=%" PRId32 "\n", hello.number);
+
+    return send_request(request);
+}
+
+static bool send_ping()
+{
+    PB_Request request = PB_Request_init_zero;
+    request.which_request = PB_Request_ping_tag;
+    PB_ReqPing &ping = request.request.ping;
+    ping.color = (PB_ColorType)Color::RED;
+
+    printf("==>> Ping request  with color=%s\n", color_name[ping.color]);
+
+    return send_request(request);
+}
+
+static bool send_pong()
+{
+    PB_Request request = PB_Request_init_zero;
+    request.which_request = PB_Request_pong_tag;
+    PB_ReqPong &pong = request.request.pong;
+    pong.has_pose = true;
+    Pose pose = {15, 30, 90};
+    pose.pb_copy(pong.pose);
+
+    printf(
+        "==>> Pong request  with pose={x=%.2lf, y=%.2lf, angle=%.2lf}\n",
+        pong.pose.x, pong.pose.y, pong.pose.angle
+        );
+
+    return send_request(request);
+}
+
+static void *message_sender(void *arg)
+{
+    (void)arg;
+    bool is_ping = true;
+
+    while (1) {
+        if (suspend_sender) {
+            suspend_sender = false;
+            thread_sleep();
+        }
+
+        if (is_ping) {
+            send_ping();
+        }
+        else {
+            send_pong();
+        }
+        is_ping = !is_ping;
+
+        riot::this_thread::sleep_for(std::chrono::seconds(2));
+    }
+
+    return NULL;
+}
+
+static int cmd_hello(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    send_hello();
+
+    return 0;
+}
+
+static int cmd_start(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    suspend_sender = false;
+    thread_wakeup(sender_pid);
+
+    return 0;
+}
+
+static int cmd_stop(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    suspend_sender = true;
+
+    return 0;
+}
+
+int main(void)
+{
+    printf("\n== UART/NanoPB Example ==\n");
+
+    int res = uart_init(uart_dev, uart_speed, uart_rx_cb, NULL);
+    printf("UART initialization status: %d\n", res);
+
+    cogip::shell::root_menu.push_back(
+        new cogip::shell::Command("hello", "Send hello", cmd_hello));
+    cogip::shell::root_menu.push_back(
+        new cogip::shell::Command("start", "Start sender thread", cmd_start));
+    cogip::shell::root_menu.push_back(
+        new cogip::shell::Command("stop", "Stop sender thread", cmd_stop));
+
+    ringbuffer_init(&(ctx.rx_buf), ctx.rx_mem, PB_Response_size);
+
+    sender_pid = thread_create(
+        sender_stack, sizeof(sender_stack), SENDER_PRIO,
+        THREAD_CREATE_SLEEPING, message_sender, NULL, "sender");
+
+    reader_pid = thread_create(
+        reader_stack, sizeof(reader_stack), READER_PRIO,
+        0, message_reader, NULL, "reader");
+
+    // Start shell
+    cogip::shell::start();
+
+    return 0;
+}

--- a/examples/uart-nanopb/pingpong.proto
+++ b/examples/uart-nanopb/pingpong.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+// All message type names are prefixed with "PB_" to avoid collisions
+// C++ classes already defined in code and Protobuf generated types.
+
+message PB_ReqHello {
+    int32 number = 1;
+}
+
+message PB_RespHello {
+    int32 number = 1;
+}
+
+enum PB_ColorType {
+    NONE = 0;
+    RED = 1;
+    GREEN = 2;
+    BLUE = 3;
+}
+
+message PB_Pose {
+    double x = 1;
+    double y = 2;
+    double angle = 3;
+}
+
+message PB_ReqPing {
+    PB_ColorType color = 1;
+}
+
+message PB_RespPing {
+    PB_ColorType color = 1;
+}
+
+message PB_ReqPong {
+    PB_Pose pose = 1;
+}
+
+message PB_RespPong {
+    PB_Pose new_pose = 1;
+}
+
+message PB_Request {
+    oneof request {
+        PB_ReqHello hello = 1;
+        PB_ReqPing ping = 2;
+        PB_ReqPong pong = 3;
+    }
+}
+
+message PB_Response {
+    oneof response {
+        PB_RespHello hello = 1;
+        PB_RespPing ping = 2;
+        PB_RespPong pong = 3;
+    }
+}

--- a/examples/uart-nanopb/requirements.txt
+++ b/examples/uart-nanopb/requirements.txt
@@ -1,0 +1,3 @@
+protobuf==3.19.1
+pyserial==3.5
+typer==0.4.0

--- a/examples/uart-nanopb/uart-nanobp.py
+++ b/examples/uart-nanopb/uart-nanobp.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+from google import protobuf
+from serial import Serial
+import typer
+
+from pingpong_pb2 import (
+    PB_Request, PB_ReqHello, PB_ReqPing, PB_ReqPong,
+    PB_Response, PB_RespPong,
+    PB_Pose, PB_ColorType
+)
+
+
+serial_port = Serial()
+
+
+def send_response(response: PB_Response) -> None:
+    response_encoded = response.SerializeToString()
+    length_bytes = int.to_bytes(len(response_encoded), 4, byteorder='little', signed=False)
+    serial_port.write(length_bytes)
+    serial_port.write(response_encoded)
+
+
+def handle_message_hello(hello: PB_ReqHello) -> None:
+    print(f"Received Hello request with number={hello.number}")
+    response = PB_Response()
+    response.hello.number = -hello.number
+    send_response(response)
+
+
+def handle_message_ping(ping: PB_ReqPing) -> None:
+    print(f"Received Ping request with color={PB_ColorType.Name(ping.color)}")
+    response = PB_Response()
+    response.ping.color = PB_ColorType.BLUE
+    send_response(response)
+
+
+def handle_message_pong(pong: PB_ReqPong) -> None:
+    print(f"Received Pong request with pose={{x={pong.pose.x}, y={pong.pose.y}, angle={pong.pose.angle}}}")
+    response = PB_Response()
+    response_pong = PB_RespPong(
+        new_pose=PB_Pose(
+            x=-pong.pose.x,
+            y=-pong.pose.y,
+            angle=-pong.pose.angle
+        )
+    )
+    response.pong.CopyFrom(response_pong)
+    send_response(response)
+
+
+request_handlers = {
+    "hello": handle_message_hello,
+    "ping": handle_message_ping,
+    "pong": handle_message_pong
+}
+
+
+def decode_message(encoded_message: str) -> None:
+    message = PB_Request()
+    try:
+        message.ParseFromString(encoded_message)
+    except protobuf.message.DecodeError as exc:
+        print(exc)
+        return -1
+    request_type = message.WhichOneof("request")
+    request_handler = request_handlers.get(request_type)
+    if request_handler:
+        request_handler(getattr(message, request_type))
+    else:
+        print(f"No handler found for request type '{request_type}'")
+
+
+def main(
+        port: Path = typer.Argument(
+            "/dev/ttyUSB0", exists=True, file_okay=True,
+            help="Serial port connected to STM32 device"),
+        baud: int = typer.Argument(
+            230400,
+            help="Baud rate")) -> None:
+    serial_port.port = str(port)
+    serial_port.baudrate = baud
+    serial_port.open()
+
+    while(True):
+        length_bytes = serial_port.readline(4)
+        message_length = int.from_bytes(length_bytes, byteorder='little')
+        encoded_message = serial_port.read(message_length)
+        decode_message(encoded_message)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
This PR only adds an example that shows the configuration and usage of a second UART,
and uses Protobuf (nanopb package) messages to exchange data over this UART.
A client written in Python is also provided.