### PR TITLE
Fix buffer sizes for Protobuf

### DIFF
--- a/sys/shell_menu/include/shell_menu/Command.hpp
+++ b/sys/shell_menu/include/shell_menu/Command.hpp
@@ -20,7 +20,7 @@
 #include "PB_Command.hpp"
 
 #ifndef COMMAND_NAME_MAX_LENGTH
-#  define COMMAND_NAME_MAX_LENGTH 16
+#  define COMMAND_NAME_MAX_LENGTH 64
 #endif
 
 #ifndef COMMAND_DESC_MAX_LENGTH

--- a/sys/uartpb/include/uartpb/uartpb.hpp
+++ b/sys/uartpb/include/uartpb/uartpb.hpp
@@ -25,7 +25,7 @@
 #endif
 
 #ifndef UARTPB_OUTPUT_MESSAGE_LENGTH_MAX
-#define UARTPB_OUTPUT_MESSAGE_LENGTH_MAX  512                ///< max outgoing message length
+#define UARTPB_OUTPUT_MESSAGE_LENGTH_MAX  1024               ///< max outgoing message length
 #endif
 
 /// @}


### PR DESCRIPTION
Increase size of shell commands and Profobuf serialization buffer to fix segfault with pf_test and cortex platforms.