### PR TITLE
uartpb: define a unique output message type

### DIFF
--- a/applications/app_test/PB_GameOutputMessage.proto
+++ b/applications/app_test/PB_GameOutputMessage.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "PB_Menu.proto";
+import "PB_State.proto";
+
+message PB_GameOutputMessage {
+    oneof type {
+        bool reset = 1;
+        PB_Menu menu = 2;
+        PB_State state = 3;
+    }
+}

--- a/applications/app_test/include/uartpb_config.hpp
+++ b/applications/app_test/include/uartpb_config.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shell_menu/Menu.hpp"
+#include "obstacles/List.hpp"
+#include "obstacles/Obstacle.hpp"
+#include "avoidance.hpp"
+#include "PB_GameOutputMessage.hpp"
+
+using PB_OutputMessage = PB_GameOutputMessage<
+    COMMAND_NAME_MAX_LENGTH,
+    NB_SHELL_COMMANDS,
+    COMMAND_NAME_MAX_LENGTH,
+    COMMAND_DESC_MAX_LENGTH,
+    AVOIDANCE_GRAPH_MAX_VERTICES,
+    OBSTACLES_MAX_NUMBER,
+    OBSTACLE_BOUNDING_BOX_VERTICES>;

--- a/applications/cup2021/PB_GameOutputMessage.proto
+++ b/applications/cup2021/PB_GameOutputMessage.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+import "PB_Menu.proto";
+import "PB_State.proto";
+
+message PB_GameOutputMessage {
+    oneof type {
+        bool reset = 1;
+        PB_Menu menu = 2;
+        PB_State state = 3;
+    }
+}

--- a/applications/cup2021/include/uartpb_config.hpp
+++ b/applications/cup2021/include/uartpb_config.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "shell_menu/Menu.hpp"
+#include "obstacles/List.hpp"
+#include "obstacles/Obstacle.hpp"
+#include "avoidance.hpp"
+#include "PB_GameOutputMessage.hpp"
+
+using PB_OutputMessage = PB_GameOutputMessage<
+    COMMAND_NAME_MAX_LENGTH,
+    NB_SHELL_COMMANDS,
+    COMMAND_NAME_MAX_LENGTH,
+    COMMAND_DESC_MAX_LENGTH,
+    AVOIDANCE_GRAPH_MAX_VERTICES,
+    OBSTACLES_MAX_NUMBER,
+    OBSTACLE_BOUNDING_BOX_VERTICES>;

--- a/examples/uartpb/PB_Color.proto
+++ b/examples/uartpb/PB_Color.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.cogip_defs;
-
 enum PB_Color {
     NONE = 0;
     RED = 1;

--- a/examples/uartpb/PB_ExampleOutputMessage.proto
+++ b/examples/uartpb/PB_ExampleOutputMessage.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+import "PB_Menu.proto";
+import "PB_ReqHello.proto";
+import "PB_ReqPing.proto";
+import "PB_ReqPong.proto";
+
+message PB_ExampleOutputMessage {
+    oneof type {
+        PB_Menu menu = 1;
+        bool reset = 2;
+        PB_ReqHello req_hello = 3;
+        PB_ReqPing req_ping = 4;
+        PB_ReqPong req_pong = 5;
+    }
+}

--- a/examples/uartpb/PB_ReqHello.proto
+++ b/examples/uartpb/PB_ReqHello.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.embedded_proto_uart;
-
 // All message type names are prefixed with "PB_" to avoid collisions
 // C++ classes already defined in code and Protobuf generated types.
 

--- a/examples/uartpb/PB_ReqPing.proto
+++ b/examples/uartpb/PB_ReqPing.proto
@@ -2,11 +2,9 @@ syntax = "proto3";
 
 import "PB_Color.proto";
 
-package cogip.embedded_proto_uart;
-
 // All message type names are prefixed with "PB_" to avoid collisions
 // C++ classes already defined in code and Protobuf generated types.
 
 message PB_ReqPing {
-    cogip_defs.PB_Color color = 1;
+    PB_Color color = 1;
 }

--- a/examples/uartpb/PB_ReqPong.proto
+++ b/examples/uartpb/PB_ReqPong.proto
@@ -2,11 +2,9 @@ syntax = "proto3";
 
 import "PB_Pose.proto";
 
-package cogip.embedded_proto_uart;
-
 // All message type names are prefixed with "PB_" to avoid collisions
 // C++ classes already defined in code and Protobuf generated types.
 
 message PB_ReqPong {
-    cogip_defs.PB_Pose pose = 1;
+    PB_Pose pose = 1;
 }

--- a/examples/uartpb/PB_RespHello.proto
+++ b/examples/uartpb/PB_RespHello.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.embedded_proto_uart;
-
 message PB_RespHello {
     int32 number = 1;
 }

--- a/examples/uartpb/PB_RespPing.proto
+++ b/examples/uartpb/PB_RespPing.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 import "PB_Color.proto";
 
-package cogip.embedded_proto_uart;
-
 message PB_RespPing {
-    cogip_defs.PB_Color color = 1;
+    PB_Color color = 1;
 }

--- a/examples/uartpb/PB_RespPong.proto
+++ b/examples/uartpb/PB_RespPong.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 import "PB_Pose.proto";
 
-package cogip.embedded_proto_uart;
-
 message PB_RespPong {
-    cogip_defs.PB_Pose new_pose = 1;
+    PB_Pose new_pose = 1;
 }

--- a/examples/uartpb/include/uartpb_config.hpp
+++ b/examples/uartpb/include/uartpb_config.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "shell_menu/Menu.hpp"
+#include "PB_ExampleOutputMessage.hpp"
+
+using PB_OutputMessage = PB_ExampleOutputMessage<
+    COMMAND_NAME_MAX_LENGTH,
+    NB_SHELL_COMMANDS,
+    COMMAND_NAME_MAX_LENGTH,
+    COMMAND_DESC_MAX_LENGTH,
+    64>;

--- a/examples/uartpb/main.cpp
+++ b/examples/uartpb/main.cpp
@@ -38,17 +38,17 @@ enum MessageType {
 
 cogip::uartpb::UartProtobuf *uartpb = nullptr;
 
-static void handle_response_hello(const cogip::embedded_proto_uart::PB_RespHello *hello)
+static void handle_response_hello(const PB_RespHello *hello)
 {
     printf("<<== Hello response with number=%" PRId32 "\n\n", (int32_t)hello->get_number());
 }
 
-static void handle_response_ping(const cogip::embedded_proto_uart::PB_RespPing *ping)
+static void handle_response_ping(const PB_RespPing *ping)
 {
     printf("<<== Ping response with color=%s\n\n", get_color_name((cogip::cogip_defs::Color)ping->get_color()));
 }
 
-static void handle_response_pong(const cogip::embedded_proto_uart::PB_RespPong *pong)
+static void handle_response_pong(const PB_RespPong *pong)
 {
     cogip::cogip_defs::Pose pose(pong->get_new_pose());
     printf(
@@ -64,15 +64,15 @@ void message_handler(uint8_t message_type, cogip::uartpb::ReadBuffer &buffer)
     response_handler_t response_handler = nullptr;
     switch (message_type) {
         case MSG_HELLO:
-            message = new cogip::embedded_proto_uart::PB_RespHello();
+            message = new PB_RespHello();
             response_handler = (response_handler_t)handle_response_hello;
             break;
         case MSG_PING:
-            message = new cogip::embedded_proto_uart::PB_RespPing();
+            message = new PB_RespPing();
             response_handler = (response_handler_t)handle_response_ping;
             break;
         case MSG_PONG:
-            message = new cogip::embedded_proto_uart::PB_RespPong();
+            message = new PB_RespPong();
             response_handler = (response_handler_t)handle_response_pong;
             break;
         default:
@@ -86,7 +86,7 @@ void message_handler(uint8_t message_type, cogip::uartpb::ReadBuffer &buffer)
 
 static bool send_hello()
 {
-    cogip::embedded_proto_uart::PB_ReqHello<64> hello;
+    PB_ReqHello<64> hello;
     hello.set_number(std::rand());
     hello.mutable_message() = "hellohello";
     printf(
@@ -99,8 +99,8 @@ static bool send_hello()
 
 static bool send_ping()
 {
-    cogip::embedded_proto_uart::PB_ReqPing ping;
-    ping.set_color((cogip::cogip_defs::PB_Color)cogip::cogip_defs::Color::RED);
+    PB_ReqPing ping;
+    ping.set_color((PB_Color)cogip::cogip_defs::Color::RED);
 
     printf("==>> Ping request  with color=%s\n", get_color_name((cogip::cogip_defs::Color)ping.get_color()));
 
@@ -109,7 +109,7 @@ static bool send_ping()
 
 static bool send_pong()
 {
-    cogip::embedded_proto_uart::PB_ReqPong pong;
+    PB_ReqPong pong;
     cogip::cogip_defs::Pose pose = {15, 30, 90};
     pose.pb_copy(pong.mutable_pose());
 

--- a/examples/uartpb/main.cpp
+++ b/examples/uartpb/main.cpp
@@ -6,6 +6,8 @@
 #include "thread.h"
 #include "xtimer.h"
 
+#include "uartpb_config.hpp"
+
 // Projet includes
 #include "shell_menu/shell_menu.hpp"
 
@@ -94,7 +96,9 @@ static bool send_hello()
         (int32_t)hello.get_number(), (const char *)hello.get_message().get_const()
         );
 
-    return uartpb->send_message((uint8_t)MSG_HELLO, hello);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_req_hello(hello);
+    return uartpb->send_message();
 }
 
 static bool send_ping()
@@ -104,7 +108,10 @@ static bool send_ping()
 
     printf("==>> Ping request  with color=%s\n", get_color_name((cogip::cogip_defs::Color)ping.get_color()));
 
-    return uartpb->send_message((uint8_t)MSG_PING, ping);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_req_ping(ping);
+    return uartpb->send_message();
+
 }
 
 static bool send_pong()
@@ -118,7 +125,9 @@ static bool send_pong()
         (double)pong.get_pose().get_x(), (double)pong.get_pose().get_y(), (double)pong.get_pose().get_O()
         );
 
-    return uartpb->send_message((uint8_t)MSG_PONG, pong);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_req_pong(pong);
+    return uartpb->send_message();
 }
 
 static void *message_sender(void *arg)
@@ -220,7 +229,9 @@ int main(void)
         sender_stack, sizeof(sender_stack), SENDER_PRIO,
         THREAD_CREATE_SLEEPING, message_sender, NULL, "sender");
 
-    uartpb->send_message((uint8_t)MSG_RESET);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_reset(true);
+    uartpb->send_message();
 
     // Start shell
     cogip::shell::register_uartpb(uartpb);

--- a/lib/avoidance/avoidance.cpp
+++ b/lib/avoidance/avoidance.cpp
@@ -323,12 +323,12 @@ void avoidance_print_path(cogip::tracefd::File &out)
 }
 
 void avoidance_pb_copy_path(
-        EmbeddedProto::RepeatedFieldFixedSize<cogip::cogip_defs::PB_Coords, AVOIDANCE_GRAPH_MAX_VERTICES> &path) {
+        EmbeddedProto::RepeatedFieldFixedSize<PB_Coords, AVOIDANCE_GRAPH_MAX_VERTICES> &path) {
     if (!_is_avoidance_computed) {
         return;
     }
 
-    cogip::cogip_defs::PB_Coords coords;
+    PB_Coords coords;
     for (auto i: _children) {
         _valid_points[i].pb_copy(coords);
         path.add(coords);

--- a/lib/avoidance/include/avoidance.hpp
+++ b/lib/avoidance/include/avoidance.hpp
@@ -95,6 +95,6 @@ void avoidance_print_path(cogip::tracefd::File &out);
  * @return
  */
 void avoidance_pb_copy_path(
-    EmbeddedProto::RepeatedFieldFixedSize<cogip::cogip_defs::PB_Coords, AVOIDANCE_GRAPH_MAX_VERTICES> &path);
+    EmbeddedProto::RepeatedFieldFixedSize<PB_Coords, AVOIDANCE_GRAPH_MAX_VERTICES> &path);
 
 /** @} */

--- a/lib/cogip_defs/PB_Coords.proto
+++ b/lib/cogip_defs/PB_Coords.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.cogip_defs;
-
 message PB_Coords {
     sint32 x = 1;
     sint32 y = 2;

--- a/lib/cogip_defs/PB_Polar.proto
+++ b/lib/cogip_defs/PB_Polar.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.cogip_defs;
-
 message PB_Polar {
     sint32 distance = 1;
     sint32 angle = 2;

--- a/lib/cogip_defs/PB_Pose.proto
+++ b/lib/cogip_defs/PB_Pose.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.cogip_defs;
-
 message PB_Pose {
     sint32 x = 1;
     sint32 y = 2;

--- a/lib/obstacles/PB_Circle.proto
+++ b/lib/obstacles/PB_Circle.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.obstacles;
-
 message PB_Circle {
     sint32 x = 1;
     sint32 y = 2;

--- a/lib/obstacles/PB_Obstacle.proto
+++ b/lib/obstacles/PB_Obstacle.proto
@@ -4,12 +4,10 @@ import "PB_Coords.proto";
 import "PB_Rectangle.proto";
 import "PB_Circle.proto";
 
-package cogip.obstacles;
-
 message PB_Obstacle {
     oneof obstacle {
         PB_Rectangle rectangle = 1;
         PB_Circle circle = 2;
     }
-    repeated cogip.cogip_defs.PB_Coords bounding_box = 3;
+    repeated PB_Coords bounding_box = 3;
 }

--- a/lib/obstacles/PB_Rectangle.proto
+++ b/lib/obstacles/PB_Rectangle.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.obstacles;
-
 message PB_Rectangle {
     sint32 x = 1;
     sint32 y = 2;

--- a/platforms/cortex/PB_State.proto
+++ b/platforms/cortex/PB_State.proto
@@ -8,11 +8,11 @@ import "PB_Obstacle.proto";
 
 message PB_State {
     PB_Mode mode = 1;
-    cogip.cogip_defs.PB_Pose pose_current = 2;
-    cogip.cogip_defs.PB_Pose pose_order = 3;
+    PB_Pose pose_current = 2;
+    PB_Pose pose_order = 3;
     uint32 cycle = 4;
-    cogip.cogip_defs.PB_Polar speed_current = 5;
-    cogip.cogip_defs.PB_Polar speed_order = 6;
-    repeated cogip.cogip_defs.PB_Coords path = 7;
-    repeated cogip.obstacles.PB_Obstacle obstacles = 8;
+    PB_Polar speed_current = 5;
+    PB_Polar speed_order = 6;
+    repeated PB_Coords path = 7;
+    repeated PB_Obstacle obstacles = 8;
 }

--- a/platforms/cortex/platform.cpp
+++ b/platforms/cortex/platform.cpp
@@ -153,7 +153,9 @@ void pf_send_pb_state(void)
     avoidance_pb_copy_path(pb_state.mutable_path());
     cogip::obstacles::pb_copy(pb_state.mutable_obstacles());
 
-    uartpb->send_message((uint8_t)MSG_STATE, pb_state);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_state(pb_state);
+    uartpb->send_message();
 }
 
 void pf_init_quadpid_params(ctrl_quadpid_parameters_t ctrl_quadpid_params)
@@ -479,7 +481,9 @@ void pf_init_tasks(void)
     else {
         cogip::shell::register_uartpb(uartpb);
         uartpb->start_reader();
-        uartpb->send_message((uint8_t)MSG_RESET);
+        PB_OutputMessage &msg = uartpb->output_message();
+        msg.set_reset(true);
+        uartpb->send_message();
     }
 
     lidar_start(LIDAR_MAX_DISTANCE, LIDAR_MINIMUN_INTENSITY);

--- a/platforms/pf_test/PB_State.proto
+++ b/platforms/pf_test/PB_State.proto
@@ -8,11 +8,11 @@ import "PB_Obstacle.proto";
 
 message PB_State {
     PB_Mode mode = 1;
-    cogip.cogip_defs.PB_Pose pose_current = 2;
-    cogip.cogip_defs.PB_Pose pose_order = 3;
+    PB_Pose pose_current = 2;
+    PB_Pose pose_order = 3;
     uint32 cycle = 4;
-    cogip.cogip_defs.PB_Polar speed_current = 5;
-    cogip.cogip_defs.PB_Polar speed_order = 6;
-    repeated cogip.cogip_defs.PB_Coords path = 7;
-    repeated cogip.obstacles.PB_Obstacle obstacles = 8;
+    PB_Polar speed_current = 5;
+    PB_Polar speed_order = 6;
+    repeated PB_Coords path = 7;
+    repeated PB_Obstacle obstacles = 8;
 }

--- a/platforms/pf_test/platform.cpp
+++ b/platforms/pf_test/platform.cpp
@@ -148,7 +148,9 @@ void pf_send_pb_state(void)
     avoidance_pb_copy_path(pb_state.mutable_path());
     cogip::obstacles::pb_copy(pb_state.mutable_obstacles());
 
-    uartpb->send_message((uint8_t)MSG_STATE, pb_state);
+    PB_OutputMessage &msg = uartpb->output_message();
+    msg.set_state(pb_state);
+    uartpb->send_message();
 }
 
 void pf_init_quadpid_params(ctrl_quadpid_parameters_t ctrl_quadpid_params)
@@ -402,7 +404,9 @@ void pf_init_tasks(void)
     else {
         cogip::shell::register_uartpb(uartpb);
         uartpb->start_reader();
-        uartpb->send_message((uint8_t)MSG_RESET);
+        PB_OutputMessage &msg = uartpb->output_message();
+        msg.set_reset(true);
+        uartpb->send_message();
     }
 
     lidar_start(LIDAR_MAX_DISTANCE, LIDAR_MINIMUN_INTENSITY);

--- a/sys/shell_menu/Makefile.dep
+++ b/sys/shell_menu/Makefile.dep
@@ -2,6 +2,5 @@ USEPKG += embedded-proto
 
 USEMODULE += shell
 USEMODULE += shell_commands
-USEMODULE += uartpb
 USEMODULE += utils
 USEMODULE += tracefd

--- a/sys/shell_menu/Menu.cpp
+++ b/sys/shell_menu/Menu.cpp
@@ -5,7 +5,6 @@
 #include <cassert>
 
 // Project includes
-#include "uartpb/UartProtobuf.hpp"
 #include "tracefd/tracefd.hpp"
 
 #include "PB_Menu.hpp"
@@ -85,7 +84,9 @@ void Menu::enter(void)
 
     cogip::tracefd::out.logf("Enter shell menu: %s", current_menu->name().c_str());
 
+#ifdef MODULE_UARTPB
     send_pb_message();
+#endif
 
     if (current_menu != previous_menu && enter_cb_) {
         enter_cb_();
@@ -108,6 +109,7 @@ void Menu::update_pb_message(void)
     }
 }
 
+#ifdef MODULE_UARTPB
 void Menu::send_pb_message(void)
 {
     if (uart_protobuf) {
@@ -117,6 +119,7 @@ void Menu::send_pb_message(void)
         uart_protobuf->send_message();
     }
 }
+#endif
 
 } // namespace shell
 

--- a/sys/shell_menu/Menu.cpp
+++ b/sys/shell_menu/Menu.cpp
@@ -5,11 +5,22 @@
 #include <cassert>
 
 // Project includes
+#include "uartpb/UartProtobuf.hpp"
 #include "tracefd/tracefd.hpp"
+
+#include "PB_Menu.hpp"
 
 namespace cogip {
 
 namespace shell {
+
+/// Protobuf message type. Shortcut for original template type.
+using PB_Message = PB_Menu<
+    COMMAND_NAME_MAX_LENGTH, NB_SHELL_COMMANDS,
+    COMMAND_NAME_MAX_LENGTH, COMMAND_DESC_MAX_LENGTH
+    >;
+
+PB_Message pb_message_;           ///< Protobuf message describing this menu.
 
 // Callback executed to enter a sub-menu
 static int _cmd_enter_sub_menu(int argc, char **argv)
@@ -101,7 +112,9 @@ void Menu::send_pb_message(void)
 {
     if (uart_protobuf) {
         update_pb_message();
-        uart_protobuf->send_message(0, pb_message_);
+        auto & output_message = uart_protobuf->output_message();
+        output_message.set_menu(pb_message_);
+        uart_protobuf->send_message();
     }
 }
 

--- a/sys/shell_menu/PB_Command.proto
+++ b/sys/shell_menu/PB_Command.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package cogip.shell;
-
 message PB_Command {
     string cmd = 1;
     string desc = 2;

--- a/sys/shell_menu/PB_Menu.proto
+++ b/sys/shell_menu/PB_Menu.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 import "PB_Command.proto";
 
-package cogip.shell;
-
 message PB_Menu {
     string name = 1;
     repeated PB_Command entries = 3;

--- a/sys/shell_menu/include/shell_menu/Menu.hpp
+++ b/sys/shell_menu/include/shell_menu/Menu.hpp
@@ -55,8 +55,10 @@ public:
     /// Update the Protobuf message describing this menu.
     void update_pb_message(void);
 
+#ifdef MODULE_UARTPB
     /// Send the Protobuf message describing this menu if uartpb is registered.
     void send_pb_message(void);
+#endif
 
 private:
     std::string name_;                ///< menu name

--- a/sys/shell_menu/include/shell_menu/Menu.hpp
+++ b/sys/shell_menu/include/shell_menu/Menu.hpp
@@ -19,9 +19,6 @@
 
 // Project includes
 #include "utils.h"
-#include "uartpb/UartProtobuf.hpp"
-
-#include "PB_Menu.hpp"
 
 #ifndef NB_SHELL_COMMANDS
 #  define NB_SHELL_COMMANDS 20    ///< max shell commands per menu
@@ -38,12 +35,6 @@ namespace shell {
 /// It is linked to its parent menu.
 class Menu : public std::list<Command *> {
 public:
-    /// Protobuf message type. Shortcut for original template type.
-    using PB_Message = PB_Menu<
-        COMMAND_NAME_MAX_LENGTH, NB_SHELL_COMMANDS,
-        COMMAND_NAME_MAX_LENGTH, COMMAND_DESC_MAX_LENGTH
-        >;
-
     /// Constructor.
     Menu(
         const std::string &name,      ///< [in] name of the menu
@@ -72,7 +63,6 @@ private:
     std::string cmd_;                 ///< command to enter this menu
     Menu *parent_;                    ///< pointer to the parent menu
     func_cb_t enter_cb_;              ///< function to execute at menu entry
-    PB_Message pb_message_;           ///< Protobuf message describing this menu.
 };
 
 } // namespace shell

--- a/sys/shell_menu/include/shell_menu/shell_menu.hpp
+++ b/sys/shell_menu/include/shell_menu/shell_menu.hpp
@@ -16,7 +16,9 @@
 #include "shell_menu/Command.hpp"
 #include "shell_menu/Menu.hpp"
 
+#ifdef MODULE_UARTPB
 #include "uartpb/UartProtobuf.hpp"
+#endif
 
 namespace cogip {
 
@@ -40,11 +42,13 @@ void rename_command(
     const std::string &new_name   ///< [in] new command name
     );
 
+#ifdef MODULE_UARTPB
 /// Register an UartProtobuf instance that will be used to send entered menus
 /// in Protobuf format over UART.
 void register_uartpb(
     cogip::uartpb::UartProtobuf *uartpb_ptr
     );
+#endif
 
 } // namespace shell
 

--- a/sys/shell_menu/include/shell_menu/shell_menu.hpp
+++ b/sys/shell_menu/include/shell_menu/shell_menu.hpp
@@ -16,6 +16,8 @@
 #include "shell_menu/Command.hpp"
 #include "shell_menu/Menu.hpp"
 
+#include "uartpb/UartProtobuf.hpp"
+
 namespace cogip {
 
 namespace shell {

--- a/sys/shell_menu/shell_menu.cpp
+++ b/sys/shell_menu/shell_menu.cpp
@@ -14,7 +14,10 @@ std::set<Command *> all_commands;
 std::list<Command *> global_commands;
 Menu *current_menu = nullptr;
 shell_command_t current_commands[NB_SHELL_COMMANDS];
+
+#ifdef MODULE_UARTPB
 cogip::uartpb::UartProtobuf *uart_protobuf = nullptr;
+#endif
 
 // Callbacks for default global commands
 static int _display_json_help(int argc, char **argv)
@@ -91,10 +94,12 @@ void rename_command(const std::string &old_name, const std::string &new_name)
     current_menu->enter();
 }
 
+#ifdef MODULE_UARTPB
 void register_uartpb(cogip::uartpb::UartProtobuf *uartpb_ptr)
 {
     uart_protobuf = uartpb_ptr;
 }
+#endif
 
 } // namespace shell
 

--- a/sys/shell_menu/shell_menu_private.hpp
+++ b/sys/shell_menu/shell_menu_private.hpp
@@ -12,7 +12,10 @@
 #pragma once
 
 #include "shell_menu/shell_menu.hpp"
+
+#ifdef MODULE_UARTPB
 #include "uartpb/UartProtobuf.hpp"
+#endif
 
 #include <map>
 #include <set>
@@ -23,7 +26,10 @@ namespace shell {
 
 extern std::map<std::string, Menu *> all_menus;     ///< map containing all menus indexed by cmd
 extern std::set<Command *> all_commands;            ///< all commands
+
+#ifdef MODULE_UARTPB
 extern cogip::uartpb::UartProtobuf *uart_protobuf;  ///< UartProtocol instance used to send new menu over UART
+#endif
 
 /// Shell commands used by RIOT shell module.
 /// It is updated each time a menu is entered or exited.

--- a/sys/uartpb/WriteBuffer.cpp
+++ b/sys/uartpb/WriteBuffer.cpp
@@ -13,12 +13,12 @@ namespace uartpb {
 
 void WriteBuffer::clear()
 {
-  write_index_ = UARTPB_METADATA_SIZE;
+  write_index_ = 0;
 }
 
 uint32_t WriteBuffer::get_size() const
 {
-  return write_index_ - UARTPB_METADATA_SIZE;
+  return write_index_;
 }
 
 uint32_t WriteBuffer::get_max_size() const
@@ -28,12 +28,12 @@ uint32_t WriteBuffer::get_max_size() const
 
 uint32_t WriteBuffer::get_available_size() const
 {
-  return UARTPB_OUTPUT_MESSAGE_LENGTH_MAX - write_index_ + UARTPB_METADATA_SIZE;
+  return UARTPB_OUTPUT_MESSAGE_LENGTH_MAX - write_index_;
 }
 
 bool WriteBuffer::push(const uint8_t byte)
 {
-  bool return_value = UARTPB_OUTPUT_MESSAGE_LENGTH_MAX + UARTPB_METADATA_SIZE > write_index_;
+  bool return_value = UARTPB_OUTPUT_MESSAGE_LENGTH_MAX > write_index_;
   if (return_value)
   {
     data_[write_index_] = byte;
@@ -44,7 +44,7 @@ bool WriteBuffer::push(const uint8_t byte)
 
 bool WriteBuffer::push(const uint8_t *bytes, const uint32_t length)
 {
-  bool return_value = UARTPB_OUTPUT_MESSAGE_LENGTH_MAX + UARTPB_METADATA_SIZE > (write_index_ + length);
+  bool return_value = UARTPB_OUTPUT_MESSAGE_LENGTH_MAX > (write_index_ + length);
   if (return_value)
   {
     memcpy(data_ + write_index_, bytes, length);
@@ -55,12 +55,7 @@ bool WriteBuffer::push(const uint8_t *bytes, const uint32_t length)
 
 uint8_t * WriteBuffer::get_data()
 {
-  return data_ + UARTPB_METADATA_SIZE;
-}
-
-void WriteBuffer::set_message_type(uint8_t type)
-{
-    data_[0] = type;
+  return data_;
 }
 
 size_t WriteBuffer::base64_encode()

--- a/sys/uartpb/include/uartpb/WriteBuffer.hpp
+++ b/sys/uartpb/include/uartpb/WriteBuffer.hpp
@@ -15,15 +15,8 @@
 #include "uartpb.hpp"
 #include "WriteBufferInterface.h"
 
-/// Reserved space at the begining of the serialization buffer to store meta data.
-///   - 1 byte for message type
-#define UARTPB_METADATA_SIZE 1
-
-/// Size of the Protobuf serialization buffer
-#define UARTPB_SERIALIZATION_BUFFER_SIZE (UARTPB_OUTPUT_MESSAGE_LENGTH_MAX + UARTPB_METADATA_SIZE)
-
 /// Size of the base64 encoding buffer
-#define UARTPB_BASE64_BUFFER_SIZE (UARTPB_SERIALIZATION_BUFFER_SIZE * 2)
+#define UARTPB_BASE64_BUFFER_SIZE (UARTPB_OUTPUT_MESSAGE_LENGTH_MAX * 2)
 
 namespace cogip {
 
@@ -53,9 +46,6 @@ public:
     /// Return a pointer to the data array.
     uint8_t * get_data();
 
-    /// Set type of the protobuf message
-    void set_message_type(uint8_t type);
-
     /// Encode the data buffer in base64 before transmission over UART.
     /// @return size of encoded message, 0 in case of failure.
     size_t base64_encode();
@@ -65,7 +55,7 @@ public:
 
 private:
     ///< array in which the serialized data is stored
-    uint8_t data_[UARTPB_SERIALIZATION_BUFFER_SIZE];
+    uint8_t data_[UARTPB_OUTPUT_MESSAGE_LENGTH_MAX];
     ///< array in which the base64 encoded serialized data is stored
     uint8_t base64_data_[UARTPB_BASE64_BUFFER_SIZE];
     ///< number of bytes currently serialized in the array


### PR DESCRIPTION
uartpb module can be used to send Protobuf messages over UART from any
level (lib, sys, platform, application).
Now, uartpb can send only one type of message, defined by the application,
containing a 'oneof' attribute (similar to 'union' in C). This attribute
must group all Protobuf types that can be sent over UART.