### PR TITLE
Ensure *.proto files are not always rebuilt

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -47,13 +47,28 @@ jobs:
         cd mcu-firmware
         source venv/bin/activate
         make
+        deactivate
+    - name: Distclean
+      run: |
+        cd mcu-firmware
+        source venv/bin/activate
         make distclean
+        deactivate
+    - name: Re-compile (check successive builds)
+      run: |
+        cd mcu-firmware
+        source venv/bin/activate
         make
+        make
+        deactivate
+    - name: Clean all (distclean + git clean)
+      run: |
+        cd mcu-firmware
+        source venv/bin/activate
         make distclean
+        git clean -dxf
         deactivate
     - name: Check coding rules
       run: |
         cd mcu-firmware
-        source venv/bin/activate
         make check-codingrules
-        deactivate

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -37,15 +37,23 @@ jobs:
     - name: Install Python packages
       run: |
         sudo apt-get install -qq python3-pip
-        sudo python3 -m pip install -r mcu-firmware/requirements.txt
+        cd mcu-firmware
+        python3 -m venv venv
+        source venv/bin/activate
+        python3 -m pip install -r requirements.txt
+        deactivate
     - name: Compile
       run: |
         cd mcu-firmware
+        source venv/bin/activate
         make
         make distclean
         make
         make distclean
+        deactivate
     - name: Check coding rules
       run: |
         cd mcu-firmware
+        source venv/bin/activate
         make check-codingrules
+        deactivate

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ Makefile.local
 # Python compiled files
 *.pyc
 
+# Python virtualenv
+venv/
+
 # Ignore download cache
 .dlcache
 

--- a/pkg/embedded-proto/Makefile
+++ b/pkg/embedded-proto/Makefile
@@ -5,25 +5,26 @@ PKG_LICENSE=GPL
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+all: $(BINDIR)/protoc_cpp $(BINDIR)/protoc_py
+
 PROTOC ?= protoc
 PROTOC_GEN_EAMS ?= $(PKGDIRBASE)/embedded-proto/protoc-gen-eams
-PROTOBUF_FILES ?= $(notdir $(wildcard $(APPDIR)/*.proto))
+PROTOBUF_FILES ?= $(wildcard $(APPDIR)/*.proto)
+PROTOC_FILES = $(sort $(PROTOBUF_FILES) $(foreach d, $(PROTOBUF_PATH), $(wildcard $(d)/*.proto)))
 PROTO_INCLUDES += $(PROTOBUF_PATH:%=-I%) -I$(APPDIR)
 
-all: build_ep protoc_cpp protoc_py
-
-protoc_cpp:
-	$(eval protoc_files := $(sort $(PROTOBUF_FILES) $(foreach d, $(PROTOBUF_PATH), $(notdir $(wildcard $(d)/*.proto)))))
+%/protoc_cpp: $(PROTOC_FILES) $(BINDIR)/$(PKG_NAME)
 	$(PROTOC) --plugin=protoc-gen-eams=$(PROTOC_GEN_EAMS) \
 		--eams_out="$(BINDIR)/$(APPLICATION_MODULE)" $(PROTO_INCLUDES) \
-		$(protoc_files)
+		$(PROTOC_FILES)
+	@touch $@
 
-protoc_py:
-	$(eval protoc_files := $(sort $(PROTOBUF_FILES) $(foreach d, $(PROTOBUF_PATH), $(notdir $(wildcard $(d)/*.proto)))))
+%/protoc_py: $(PROTOC_FILES) $(BINDIR)/$(PKG_NAME)
 	$(PROTOC) --python_out="$(APPDIR)" $(PROTO_INCLUDES) \
-		$(protoc_files)
+		$(PROTOC_FILES)
+	@touch $@
 
-build_ep:
+%/$(PKG_NAME):
 	# Create the directory containing generated headers
 	# so it can be included in all modules, even if no headers are generated yet.
 	# (including not existing directories will produce compilation errors)


### PR DESCRIPTION
Create a stamp file when *.protoc files are built to not rebuild
python and C bindings at each build, which could be long.

Also add some CI improvments to handle generated files