### PR TITLE
Add RIOT patching mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ pkg/*
 
 # Protobuf generated files
 *_pb2.py
+
+# Patches timestamp files
+patches/*.patched

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ Edit ~/.bashrc file and add $HOME/toolchain/gcc-arm-none-eabi-8-2018-q4-major/bi
 PATH=${PATH}:$HOME/toolchain/gcc-arm-none-eabi-8-2018-q4-major/bin/
 ```
 
+### Quilt
+
+Quilt is a tool to manage large sets of patches by keeping track of the changes each patch makes.
+It is used to apply patches on RIOT-OS
+
+```bash
+$ sudo apt install quilt
+```
+
 ### Python Virtual Environment
 
 ```bash

--- a/riot-patches/0001-sys-newlib_syscalls_default-set-_init-and-_fini-as-w.patch
+++ b/riot-patches/0001-sys-newlib_syscalls_default-set-_init-and-_fini-as-w.patch
@@ -1,0 +1,39 @@
+From 945e5c94e727969e1f2964f27ca7e0e4ec7ee695 Mon Sep 17 00:00:00 2001
+From: Gilles DOFFE <g.doffe@gmail.com>
+Date: Mon, 1 Aug 2022 15:35:24 +0200
+Subject: [PATCH] sys/newlib_syscalls_default: set _init() and _fini() as weak
+
+The _init() and _fini() functions are already defined into the
+C RunTime (crti.o) object file provided by the arm-none-eabi toolchain.
+To avoid multiple definition error, set them as 'weak'.
+
+Signed-off-by: Gilles DOFFE <g.doffe@gmail.com>
+---
+ sys/newlib_syscalls_default/syscalls.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sys/newlib_syscalls_default/syscalls.c b/sys/newlib_syscalls_default/syscalls.c
+index ab692e831d..336638aa5f 100644
+--- a/sys/newlib_syscalls_default/syscalls.c
++++ b/sys/newlib_syscalls_default/syscalls.c
+@@ -149,7 +149,7 @@ static const struct heap heaps[NUM_HEAPS] = {
+ /**
+  * @brief Initialize NewLib, called by __libc_init_array() from the startup script
+  */
+-void _init(void)
++__attribute__ ((weak)) void _init(void)
+ {
+     /* nothing to do here */
+ }
+@@ -158,7 +158,7 @@ void _init(void)
+  * @brief Free resources on NewLib de-initialization, not used for RIOT
+  */
+ /* __attribute__((used)) fixes linker errors when building with LTO, but without nano.specs */
+-__attribute__((used)) void _fini(void)
++__attribute__ ((weak)) __attribute__((used)) void _fini(void)
+ {
+     /* nothing to do here */
+ }
+-- 
+2.37.0
+


### PR DESCRIPTION
All patches available in patches/ directory will be applied on RIOT sources using quilt.
A patched stamp file is created for each patch applied.
In case of patch deletion, launch a make distclean first.

A first patch to add weak attribute to _init() and _fini() functions in preparation of using libstdc++ is also added.