### PR TITLE
sys: shell_menu: remove dynamic allocation

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install toolchain
       run: |
         sudo apt-get update
-        sudo apt-get install -qq build-essential gcc-multilib g++-multilib gcc-arm-none-eabi libnewlib-arm-none-eabi uncrustify protobuf-compiler
+        sudo apt-get install -qq build-essential gcc-multilib g++-multilib gcc-arm-none-eabi libnewlib-arm-none-eabi uncrustify protobuf-compiler quilt
         gcc --version
         arm-none-eabi-gcc --version
     - name: Install Python packages

--- a/Makefile.include
+++ b/Makefile.include
@@ -18,9 +18,9 @@ DEVELHELP ?= 1
 
 # Required features
 FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += libstdcpp
 
 # Required modules
-USEMODULE += cpp11-compat
 USEMODULE += ztimer_sec
 USEMODULE += ztimer_msec
 USEMODULE += ztimer_usec
@@ -84,6 +84,13 @@ CXXEXFLAGS = $(filter-out -std=%, $(tmp_cxxexflags))
 CXXEXFLAGS += -std=c++17
 CXXEXFLAGS += -Wno-pedantic
 CXXEXFLAGS += -Wno-cast-align
+
+LINKFLAGS:=$(filter-out -nostartfiles,$(LINKFLAGS))
+
+# Using libstdcpp requires a larger ISR stack by default
+ifeq (,$(findstring -DISR_STACKSIZE=,$(CFLAGS)))
+	CFLAGS += -DISR_STACKSIZE=2048
+endif
 
 .PHONY: world
 world: all

--- a/applications/app_test/app_shell.cpp
+++ b/applications/app_test/app_shell.cpp
@@ -20,7 +20,7 @@ static void *_wizard_thread_command(void *arg)
     return EXIT_SUCCESS;
 }
 
-static int _cmd_wizard(int argc, char **argv)
+static int _cmd_wizard_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -37,7 +37,7 @@ static int _cmd_wizard(int argc, char **argv)
     return 0;
 }
 
-static int _cmd_samples(int argc, char **argv)
+static int _cmd_samples_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -45,13 +45,13 @@ static int _cmd_samples(int argc, char **argv)
     return 0;
 }
 
+static cogip::shell::Command _cmd_wizard = { "wizard", "Run Wizard", _cmd_wizard_cb };
+static cogip::shell::Command _cmd_samples = { "_samples", "Get detected samples", _cmd_samples_cb };
+
 void app_shell_init()
 {
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("wizard", "Run Wizard", _cmd_wizard));
-
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("_samples", "Get detected samples", _cmd_samples));
+    cogip::shell::root_menu().push_back(&_cmd_wizard);
+    cogip::shell::root_menu().push_back(&_cmd_samples);
 }
 
 } // namespace app

--- a/applications/cup2022/app_shell.cpp
+++ b/applications/cup2022/app_shell.cpp
@@ -20,7 +20,7 @@ static void *_wizard_thread_command(void *arg)
     return EXIT_SUCCESS;
 }
 
-static int _cmd_wizard(int argc, char **argv)
+static int _cmd_wizard_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -37,7 +37,7 @@ static int _cmd_wizard(int argc, char **argv)
     return 0;
 }
 
-static int _cmd_samples(int argc, char **argv)
+static int _cmd_samples_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -45,13 +45,13 @@ static int _cmd_samples(int argc, char **argv)
     return 0;
 }
 
+static cogip::shell::Command _cmd_wizard = { "wizard", "Run Wizard", _cmd_wizard_cb };
+static cogip::shell::Command _cmd_samples = { "_samples", "Get detected samples", _cmd_samples_cb };
+
 void app_shell_init()
 {
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("wizard", "Run Wizard", _cmd_wizard));
-
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("_samples", "Get detected samples", _cmd_samples));
+    cogip::shell::root_menu().push_back(&_cmd_wizard);
+    cogip::shell::root_menu().push_back(&_cmd_samples);
 }
 
 } // namespace app

--- a/controllers/quadpid/shell_quadpid/shell_quadpid.cpp
+++ b/controllers/quadpid/shell_quadpid/shell_quadpid.cpp
@@ -758,45 +758,43 @@ static int ctrl_quadpid_pose_cmd_angular_kp_cb(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
+static cogip::shell::Menu _menu_speed = { "QuadPID controller speed menu", "ctrl_quadpid_speed_menu", &cogip::shell::root_menu() };
+static cogip::shell::Command _cmd_speed_l = { "l", "Linear speed characterization", ctrl_quadpid_speed_cmd_linear_speed_cb };
+static cogip::shell::Command _cmd_speed_a = { "a", "Angular speed characterization", ctrl_quadpid_speed_cmd_angular_speed_cb };
+static cogip::shell::Command _cmd_speed_L = { "L", "Linear speed PID test", ctrl_quadpid_speed_cmd_linear_pid_cb };
+static cogip::shell::Command _cmd_speed_A = { "A", "Angular speed PID test", ctrl_quadpid_speed_cmd_angular_pid_cb };
+static cogip::shell::Command _cmd_speed_p = { "p", "Set linear Kp to <kp>", ctrl_quadpid_speed_cmd_set_linear_kp_cb };
+static cogip::shell::Command _cmd_speed_i = { "i", "Set linear Ki to <ki>", ctrl_quadpid_speed_cmd_set_linear_ki_cb };
+static cogip::shell::Command _cmd_speed_d = { "d", "Set linear Kd to <kd>", ctrl_quadpid_speed_cmd_set_linear_kd_cb };
+static cogip::shell::Command _cmd_speed_P = { "P", "Set angular Kp to <kp>", ctrl_quadpid_speed_cmd_set_angular_kp_cb };
+static cogip::shell::Command _cmd_speed_I = { "I", "Set angular Ki to <ki>", ctrl_quadpid_speed_cmd_set_angular_ki_cb };
+static cogip::shell::Command _cmd_speed_D = { "D", "Set angular Kd to <kd>", ctrl_quadpid_speed_cmd_set_angular_kd_cb };
+static cogip::shell::Command _cmd_speed_r = { "r", "Reset PID coefficients to (Kp = 1, Ki = 0, Kd = 0)", ctrl_quadpid_speed_cmd_reset_coef_cb };
+
+static cogip::shell::Menu _menu_pose = { "QuadPID controller pose menu", "ctrl_quadpid_pose_menu", &cogip::shell::root_menu() };
+static cogip::shell::Command _cmd_pose_a = { "a", "Speed linear Kp calibration to <kp>", ctrl_quadpid_pose_cmd_linear_kp_cb };
+static cogip::shell::Command _cmd_pose_A = { "A", "Speed angular Kp calibration to <kp>", ctrl_quadpid_pose_cmd_angular_kp_cb };
+static cogip::shell::Command _cmd_pose_e = { "e", "Encoder reset command", ctrl_quadpid_pose_cmd_reset_cb };
+
 void ctrl_quadpid_shell_init(ctrl_quadpid_t *ctrl_quadpid_new)
 {
     ctrl_quadpid = ctrl_quadpid_new;
 
-    /* ctrl_quadpid speed menu and commands */
-    cogip::shell::Menu *menu_speed = new cogip::shell::Menu(
-        "QuadPID controller speed menu", "ctrl_quadpid_speed_menu", &cogip::shell::root_menu);
+    /* ctrl_quadpid speed menu */
+    _menu_speed.push_back(&_cmd_speed_l);
+    _menu_speed.push_back(&_cmd_speed_a);
+    _menu_speed.push_back(&_cmd_speed_L);
+    _menu_speed.push_back(&_cmd_speed_A);
+    _menu_speed.push_back(&_cmd_speed_p);
+    _menu_speed.push_back(&_cmd_speed_i);
+    _menu_speed.push_back(&_cmd_speed_d);
+    _menu_speed.push_back(&_cmd_speed_P);
+    _menu_speed.push_back(&_cmd_speed_I);
+    _menu_speed.push_back(&_cmd_speed_D);
+    _menu_speed.push_back(&_cmd_speed_r);
 
-    menu_speed->push_back(new cogip::shell::Command(
-        "l", "Linear speed characterization", ctrl_quadpid_speed_cmd_linear_speed_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "a", "Angular speed characterization", ctrl_quadpid_speed_cmd_angular_speed_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "L", "Linear speed PID test", ctrl_quadpid_speed_cmd_linear_pid_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "A", "Angular speed PID test", ctrl_quadpid_speed_cmd_angular_pid_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "p", "Set linear Kp to <kp>", ctrl_quadpid_speed_cmd_set_linear_kp_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "i", "Set linear Ki to <ki>", ctrl_quadpid_speed_cmd_set_linear_ki_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "d", "Set linear Kd to <kd>", ctrl_quadpid_speed_cmd_set_linear_kd_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "P", "Set angular Kp to <kp>", ctrl_quadpid_speed_cmd_set_angular_kp_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "I", "Set angular Ki to <ki>", ctrl_quadpid_speed_cmd_set_angular_ki_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "D", "Set angular Kd to <kd>", ctrl_quadpid_speed_cmd_set_angular_kd_cb));
-    menu_speed->push_back(new cogip::shell::Command(
-        "r", "Reset PID coefficients to (Kp = 1, Ki = 0, Kd = 0)", ctrl_quadpid_speed_cmd_reset_coef_cb));
-
-    /* ctrl_quadpid pose menu and commands */
-    cogip::shell::Menu *menu_pose = new cogip::shell::Menu(
-        "QuadPID controller pose menu", "ctrl_quadpid_pose_menu", &cogip::shell::root_menu);
-
-    menu_pose->push_back(new cogip::shell::Command(
-        "a", "Speed linear Kp calibration to <kp>", ctrl_quadpid_pose_cmd_linear_kp_cb));
-    menu_pose->push_back(new cogip::shell::Command(
-        "A", "Speed angular Kp calibration to <kp>", ctrl_quadpid_pose_cmd_angular_kp_cb));
-    menu_pose->push_back(new cogip::shell::Command(
-        "e", "Encoder reset command", ctrl_quadpid_pose_cmd_reset_cb));
+    /* ctrl_quadpid pose menu */
+    _menu_pose.push_back(&_cmd_pose_a);
+    _menu_pose.push_back(&_cmd_pose_A);
+    _menu_pose.push_back(&_cmd_pose_e);
 }

--- a/drivers/sd21/shell_sd21/shell_sd21.cpp
+++ b/drivers/sd21/shell_sd21/shell_sd21.cpp
@@ -166,32 +166,31 @@ static int sd21_cmd_switch_cb(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
+static cogip::shell::Menu _menu_sd21 = { "SD21 menu", "sd21_menu", &cogip::shell::root_menu() };
+static cogip::shell::Command _cmd_d = { "d", "sd21 device <d>", sd21_cmd_device_cb };
+static cogip::shell::Command _cmd_o = { "o", "Opened position", sd21_cmd_opened_cb };
+static cogip::shell::Command _cmd_c = { "c", "Closed position", sd21_cmd_closed_cb };
+static cogip::shell::Command _cmd_n = { "n", "Next servomotor", sd21_cmd_next_servo_cb };
+static cogip::shell::Command _cmd_p = { "p", "Previous servomotor", sd21_cmd_previous_servo_cb };
+static cogip::shell::Command _cmd_r = { "r", "Reset to center position", sd21_cmd_reset_cb };
+static cogip::shell::Command _cmd_inc = { "+", "Add " STR(SD21_SERVO_POS_STEP) "microseconds to current position", sd21_cmd_add_cb };
+static cogip::shell::Command _cmd_dec = { "-", "Substract " STR(SD21_SERVO_POS_STEP) "microseconds from current position", sd21_cmd_sub_cb };
+static cogip::shell::Command _cmd_switch = { "switch", "Switch to predefined position <n> (n between 0 and 9)", sd21_cmd_switch_cb };
+
 extern "C"
 void sd21_shell_init(const sd21_conf_t *sd21_config_new)
 {
     /* SD21 new_config */
     sd21_config = sd21_config_new;
 
-    /* SD21 menu and commands */
-    cogip::shell::Menu *menu = new cogip::shell::Menu(
-        "SD21 menu", "sd21_menu", &cogip::shell::root_menu);
-
-    menu->push_back(new cogip::shell::Command(
-        "d", "sd21 device <d>", sd21_cmd_device_cb));
-    menu->push_back(new cogip::shell::Command(
-        "o", "Opened position", sd21_cmd_opened_cb));
-    menu->push_back(new cogip::shell::Command(
-        "c", "Closed position", sd21_cmd_closed_cb));
-    menu->push_back(new cogip::shell::Command(
-        "n", "Next servomotor", sd21_cmd_next_servo_cb));
-    menu->push_back(new cogip::shell::Command(
-        "p", "Previous servomotor", sd21_cmd_previous_servo_cb));
-    menu->push_back(new cogip::shell::Command(
-        "r", "Reset to center position", sd21_cmd_reset_cb));
-    menu->push_back(new cogip::shell::Command(
-        "+", "Add " STR(SD21_SERVO_POS_STEP) "microseconds to current position", sd21_cmd_add_cb));
-    menu->push_back(new cogip::shell::Command(
-        "-", "Substract " STR(SD21_SERVO_POS_STEP) "microseconds from current position", sd21_cmd_sub_cb));
-    menu->push_back(new cogip::shell::Command(
-        "switch", "Switch to predefined position <n> (n between 0 and 9)", sd21_cmd_switch_cb));
+    /* SD21 menu */
+    _menu_sd21.push_back(&_cmd_d);
+    _menu_sd21.push_back(&_cmd_o);
+    _menu_sd21.push_back(&_cmd_c);
+    _menu_sd21.push_back(&_cmd_n);
+    _menu_sd21.push_back(&_cmd_p);
+    _menu_sd21.push_back(&_cmd_r);
+    _menu_sd21.push_back(&_cmd_inc);
+    _menu_sd21.push_back(&_cmd_dec);
+    _menu_sd21.push_back(&_cmd_switch);
 }

--- a/examples/lidar_obstacles/lidar_obstacles.cpp
+++ b/examples/lidar_obstacles/lidar_obstacles.cpp
@@ -3,6 +3,7 @@
 
 // RIOT includes
 #include <ztimer.h>
+#include "time_units.h"
 
 // Project includes
 #include "lds01.h"

--- a/examples/lidar_obstacles/main.cpp
+++ b/examples/lidar_obstacles/main.cpp
@@ -99,18 +99,22 @@ static void* _trace_thread(void *data)
     }
 }
 
+static cogip::shell::Command _cmd_trace_on = { "_trace_on", "Activate/deactivate trace", _cmd_trace_on_off };
+static cogip::shell::Command _cmd_lidar_data = { "_lidar_data",  "Print Lidar data", lidar_cmd_print_data };
+#ifdef MODULE_SHMEM
+static cogip::shell::Command _cmd_shmem = SHMEM_SET_KEY_CMD;
+#endif
+
 int main(void)
 {
     COGIP_DEBUG_COUT("== Lidar obstacle detection example ==");
 
     // Add print data command
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("_trace_on", "Activate/deactivate trace", _cmd_trace_on_off));
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("_lidar_data", "Print Lidar data", lidar_cmd_print_data));
+    cogip::shell::root_menu().push_back(&_cmd_trace_on);
+    cogip::shell::root_menu().push_back(&_cmd_lidar_data);
 
 #ifdef MODULE_SHMEM
-    cogip::shell::root_menu.push_back(new cogip::shell::Command(SHMEM_SET_KEY_CMD));
+    cogip::shell::root_menu().push_back(&_cmd_shmem);
 #endif
 
     _init_border_obstacles();

--- a/examples/shell_menu/main.cpp
+++ b/examples/shell_menu/main.cpp
@@ -4,7 +4,7 @@
 
 bool trace_on = false;
 
-static int cmd_global(int argc, char **argv)
+static int func_global(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -12,7 +12,7 @@ static int cmd_global(int argc, char **argv)
     return 0;
 }
 
-static int cmd_trace_on_off(int argc, char **argv)
+static int func_trace_on_off(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -29,7 +29,7 @@ static int cmd_trace_on_off(int argc, char **argv)
     return 0;
 }
 
-static int cmd_1(int argc, char **argv)
+static int func_1(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -37,7 +37,7 @@ static int cmd_1(int argc, char **argv)
     return 0;
 }
 
-static int cmd_2(int argc, char **argv)
+static int func_2(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -45,7 +45,7 @@ static int cmd_2(int argc, char **argv)
     return 0;
 }
 
-static int cmd_1_1(int argc, char **argv)
+static int func_1_1(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -53,7 +53,7 @@ static int cmd_1_1(int argc, char **argv)
     return 0;
 }
 
-static int cmd_1_2(int argc, char **argv)
+static int func_1_2(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -61,7 +61,7 @@ static int cmd_1_2(int argc, char **argv)
     return 0;
 }
 
-static int cmd_2_1(int argc, char **argv)
+static int func_2_1(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -69,7 +69,7 @@ static int cmd_2_1(int argc, char **argv)
     return 0;
 }
 
-static int cmd_2_2(int argc, char **argv)
+static int func_2_2(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -77,7 +77,7 @@ static int cmd_2_2(int argc, char **argv)
     return 0;
 }
 
-static int cmd_2_1_sub(int argc, char **argv)
+static int func_2_1_sub(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -90,39 +90,44 @@ void module1_enter_callback(void)
     puts("Execute module1 enter callback");
 }
 
+cogip::shell::Command cmd_global = { "global", "Global command", func_global };
+cogip::shell::Command cmd_trace_on_off = { "trace_on", "Activate/deactivate trace", func_trace_on_off };
+cogip::shell::Command cmd_1 = { "cmd_1", "Command 1", func_1 };
+cogip::shell::Command cmd_2 = { "cmd_2", "Command 2", func_2 };
+
+cogip::shell::Menu menu_mod1 = { "Module 1 menu", "mod1", &cogip::shell::root_menu(), module1_enter_callback };
+cogip::shell::Command cmd_1_1 = { "cmd_1", "Module 1 command 1", func_1_1 };
+cogip::shell::Command cmd_1_2 = { "cmd_2", "Module 1 command 2", func_1_2 };
+
+cogip::shell::Menu menu_mod2 = { "Module 2 menu", "mod2", &cogip::shell::root_menu() };
+cogip::shell::Command cmd_2_1 = { "cmd_1", "Module 2 command 1", func_2_1 };
+cogip::shell::Command cmd_2_2 = { "cmd_2", "Module 2 command 2", func_2_2 };
+
+cogip::shell::Menu menu_mod2_sub = { "Module 2 sub-menu", "mod2_sub", &menu_mod2 };
+cogip::shell::Command cmd_2_1_sub = { "cmd_1", "Module 2 sub-menu command", func_2_1_sub };
+
 void module1_init(void)
 {
-    cogip::shell::Menu *menu = new cogip::shell::Menu(
-        "Module 1 menu", "mod1", &cogip::shell::root_menu, module1_enter_callback);
-    menu->push_back(new cogip::shell::Command("cmd_1", "Module 1 command 1", cmd_1_1));
-    menu->push_back(new cogip::shell::Command("cmd_2", "Module 1 command 2", cmd_1_2));
+    menu_mod1.push_back(&cmd_1_1);
+    menu_mod1.push_back(&cmd_1_2);
 }
 
 void module2_init(void)
 {
-    cogip::shell::Menu *menu = new cogip::shell::Menu(
-        "Module 2 menu", "mod2", &cogip::shell::root_menu);
-    menu->push_back(new cogip::shell::Command("cmd_1", "Module 2 command 1", cmd_2_1));
-    menu->push_back(new cogip::shell::Command("cmd_2", "Module 2 command 2", cmd_2_2));
+    menu_mod2.push_back(&cmd_2_1);
+    menu_mod2.push_back(&cmd_2_2);
 
     // Add a sub menu in the module
-    cogip::shell::Menu *sub_menu = new cogip::shell::Menu(
-        "Module 2 sub-menu", "mod2_sub", menu);
-    sub_menu->push_back(
-        new cogip::shell::Command("cmd_1", "Module 2 sub-menu command", cmd_2_1_sub));
+    menu_mod2_sub.push_back(&cmd_2_1_sub);
 }
 
 void app_init(void)
 {
-    cogip::shell::add_global_command(
-        new cogip::shell::Command("global", "Global command", cmd_global));
-    cogip::shell::add_global_command(
-        new cogip::shell::Command("trace_on", "Activate/deactivate trace", cmd_trace_on_off));
+    cogip::shell::add_global_command(&cmd_global);
+    cogip::shell::add_global_command(&cmd_trace_on_off);
 
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("cmd_1", "Command 1", cmd_1));
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("cmd_2", "Command 2", cmd_2));
+    cogip::shell::root_menu().push_back(&cmd_1);
+    cogip::shell::root_menu().push_back(&cmd_2);
 }
 
 int main(void)

--- a/examples/shmem/main.cpp
+++ b/examples/shmem/main.cpp
@@ -27,16 +27,18 @@ static int print_data_cmd_cb(int argc, char **argv)
     return 0;
 }
 
+static cogip::shell::Command _cmd_data = { "data", "Print data from the shared memory", print_data_cmd_cb };
+static cogip::shell::Command _cmd_shmem = SHMEM_SET_KEY_CMD;
+
 int main(void)
 {
     puts("\n== shmem example ==");
 
     // make set_key command available in all menus
-    cogip::shell::add_global_command(new cogip::shell::Command(SHMEM_SET_KEY_CMD));
+    cogip::shell::root_menu().push_back(&_cmd_shmem);
 
     // Add print data command
-    cogip::shell::root_menu.push_back(new cogip::shell::Command(
-        "data", "Print data from the shared memory", print_data_cmd_cb));
+    cogip::shell::root_menu().push_back(&_cmd_data);
 
     // Start shell
     cogip::shell::start();

--- a/examples/uartpb/main.cpp
+++ b/examples/uartpb/main.cpp
@@ -126,7 +126,7 @@ static void *message_sender(void *arg)
     return NULL;
 }
 
-static int cmd_hello(int argc, char **argv)
+static int _cmd_hello_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -136,7 +136,7 @@ static int cmd_hello(int argc, char **argv)
     return 0;
 }
 
-static int cmd_start(int argc, char **argv)
+static int _cmd_start_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -147,7 +147,7 @@ static int cmd_start(int argc, char **argv)
     return 0;
 }
 
-static int cmd_stop(int argc, char **argv)
+static int _cmd_stop_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -157,7 +157,7 @@ static int cmd_stop(int argc, char **argv)
     return 0;
 }
 
-static int cmd_sub(int argc, char **argv)
+static int _cmd_sub_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -167,21 +167,23 @@ static int cmd_sub(int argc, char **argv)
     return 0;
 }
 
+static cogip::shell::Command _cmd_hello = { "hello", "Send hello", _cmd_hello_cb };
+static cogip::shell::Command _cmd_start = { "start", "Start sender thread", _cmd_start_cb };
+static cogip::shell::Command _cmd_stop = { "stop", "Stop sender thread", _cmd_stop_cb };
+
+static cogip::shell::Menu _menu_sub = { "Sub-menu", "sub", &cogip::shell::root_menu() };
+static cogip::shell::Command _cmd_sub = { "cmd", "Sub-menu command", _cmd_sub_cb };
+
 int main(void)
 {
     std::cout << std::endl << "== UART/EmbeddedProto Example ==" << std::endl;
 
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("hello", "Send hello", cmd_hello));
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("start", "Start sender thread", cmd_start));
-    cogip::shell::root_menu.push_back(
-        new cogip::shell::Command("stop", "Stop sender thread", cmd_stop));
+    cogip::shell::root_menu().push_back(&_cmd_hello);
+    cogip::shell::root_menu().push_back(&_cmd_start);
+    cogip::shell::root_menu().push_back(&_cmd_stop);
 
     // Add a sub-menu
-    cogip::shell::Menu *menu = new cogip::shell::Menu(
-        "Sub-menu", "sub", &cogip::shell::root_menu);
-    menu->push_back(new cogip::shell::Command("cmd", "Sub-menu command", cmd_sub));
+    _menu_sub.push_back(&_cmd_sub);
 
     uartpb = new cogip::uartpb::UartProtobuf(UART_DEV(1));
 

--- a/examples/uartpb/uartpb-client.py
+++ b/examples/uartpb/uartpb-client.py
@@ -21,7 +21,7 @@ from PB_Menu_pb2 import PB_Menu
 
 serial_port = Serial()
 
-menu_uuid = 2168120333
+menu_uuid = 1485239280
 reset_uuid = 3351980141
 req_hello_uuid = 3938291130
 req_ping_uuid = 2537089183

--- a/planners/shell_planners/shell_planners.cpp
+++ b/planners/shell_planners/shell_planners.cpp
@@ -90,6 +90,14 @@ void pln_menu_enter(void)
     planner->start();
 }
 
+static cogip::shell::Menu _menu_planner = { "Planners menu", "pln_menu", &cogip::shell::root_menu(), pln_menu_enter };
+static cogip::shell::Command _cmd_n = { "n", "Go to next position", pln_cmd_go_next_cb };
+static cogip::shell::Command _cmd_p = { "p", "Go to previous position", pln_cmd_go_previous_cb };
+static cogip::shell::Command _cmd_s = { "s", "Go back to start position", pln_cmd_go_start_cb };
+static cogip::shell::Command _cmd_a = { "a", "Launch action", pln_cmd_launch_action_cb };
+static cogip::shell::Command _cmd_P = { "P", "Play", pln_cmd_play_cb };
+static cogip::shell::Command _cmd_S = { "S", "Stop", pln_cmd_stop_cb };
+
 /* Init shell commands */
 void pln_shell_init(cogip::planners::Planner *pln)
 {
@@ -97,20 +105,11 @@ void pln_shell_init(cogip::planners::Planner *pln)
 
     /* Planners menu and commands */
     if (! planner_menu) {
-        planner_menu = new cogip::shell::Menu(
-            "Planners menu", "pln_menu", &cogip::shell::root_menu, pln_menu_enter);
-
-        planner_menu->push_back(new cogip::shell::Command(
-            "n", "Go to next position", pln_cmd_go_next_cb));
-        planner_menu->push_back(new cogip::shell::Command(
-            "p", "Go to previous position", pln_cmd_go_previous_cb));
-        planner_menu->push_back(new cogip::shell::Command(
-            "s", "Go back to start position", pln_cmd_go_start_cb));
-        planner_menu->push_back(new cogip::shell::Command(
-            "a", "Launch action", pln_cmd_launch_action_cb));
-        planner_menu->push_back(new cogip::shell::Command(
-            "P", "Play", pln_cmd_play_cb));
-        planner_menu->push_back(new cogip::shell::Command(
-            "S", "Stop", pln_cmd_stop_cb));
+        _menu_planner.push_back(&_cmd_n);
+        _menu_planner.push_back(&_cmd_p);
+        _menu_planner.push_back(&_cmd_s);
+        _menu_planner.push_back(&_cmd_a);
+        _menu_planner.push_back(&_cmd_P);
+        _menu_planner.push_back(&_cmd_S);
     }
 }

--- a/platforms/shell_platforms/shell_platforms.cpp
+++ b/platforms/shell_platforms/shell_platforms.cpp
@@ -31,7 +31,7 @@
 /* Controller */
 static ctrl_t *ctrl = NULL;
 
-static int _cmd_print_state(int argc, char **argv)
+static int _cmd_print_state_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -41,7 +41,7 @@ static int _cmd_print_state(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
-int pf_motors_test(int argc, char **argv)
+static int _cmd_motors_test_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -106,7 +106,7 @@ int pf_motors_test(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
-int _cmd_print_avoidance_path(int argc, char **argv)
+static int _cmd_print_avoidance_path_cb(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
@@ -116,25 +116,26 @@ int _cmd_print_avoidance_path(int argc, char **argv)
     return EXIT_SUCCESS;
 }
 
+static cogip::shell::Command _cmd_print_state = { "_state", "Print current state", _cmd_print_state_cb };
+static cogip::shell::Command _cmd_print_avoidance_path = { "_avoidance_path", "Print avoidance current path", _cmd_print_avoidance_path_cb };
+#ifdef MODULE_SHMEM
+static cogip::shell::Command cmd_shmem = SHMEM_SET_KEY_CMD;
+#endif
+
+static cogip::shell::Menu _menu_pf = { "Platforms menu", "pf_menu", &cogip::shell::root_menu() };
+static cogip::shell::Command _cmd_motors_test = { "mt", "Test all DC motors", _cmd_motors_test_cb };
+
 void pf_shell_init(void)
 {
     ctrl = pf_get_ctrl();
 
     /* Global commands */
-    cogip::shell::add_global_command(new cogip::shell::Command(
-        "_state", "Print current state", _cmd_print_state
-    ));
-    cogip::shell::add_global_command(new cogip::shell::Command(
-        "_avoidance_path", "Print avoidance current path", _cmd_print_avoidance_path
-    ));
+    cogip::shell::add_global_command(&_cmd_print_state);
+    cogip::shell::add_global_command(&_cmd_print_avoidance_path);
 #ifdef MODULE_SHMEM
-    cogip::shell::add_global_command(new cogip::shell::Command(SHMEM_SET_KEY_CMD));
+    cogip::shell::add_global_command(&cmd_shmem);
 #endif
 
-    /* Platforms menu and commands */
-    cogip::shell::Menu *menu = new cogip::shell::Menu(
-        "Platforms menu", "pf_menu", &cogip::shell::root_menu);
-
-    menu->push_back(new cogip::shell::Command(
-        "mt", "Test all DC motors", pf_motors_test));
+    /* Platforms commands */
+    _menu_pf.push_back(&_cmd_motors_test);
 }

--- a/sys/shell_menu/Command.cpp
+++ b/sys/shell_menu/Command.cpp
@@ -5,15 +5,18 @@ namespace cogip {
 
 namespace shell {
 
-Command::Command(const ::std::string &name, const ::std::string &desc, shell_command_handler_t handler)
-    : name_(name), desc_(desc), handler_(handler)
+Command::Command(
+    const etl::string<COMMAND_NAME_MAX_LENGTH> &name,
+    const etl::string<COMMAND_DESC_MAX_LENGTH> &desc,
+    shell_command_handler_t handler
+    ) : name_(name), desc_(desc), handler_(handler)
 {
-    all_commands.insert(this);
+    all_commands().insert(this);
 }
 
 Command::~Command()
 {
-    all_commands.erase(this);
+    all_commands().erase(this);
 }
 
 void Command::update_pb_message(void)

--- a/sys/shell_menu/Menu.cpp
+++ b/sys/shell_menu/Menu.cpp
@@ -10,6 +10,12 @@ namespace cogip {
 
 namespace shell {
 
+std::ostream& operator << (std::ostream& os, const etl::istring& str)
+{
+    os << str.c_str();
+    return os;
+}
+
 /// Protobuf message type. Shortcut for original template type.
 using PB_Message = PB_Menu<
     COMMAND_NAME_MAX_LENGTH, NB_SHELL_COMMANDS,
@@ -24,8 +30,8 @@ static int _cmd_enter_sub_menu(int argc, char **argv)
     (void)argc;
     (void)argv;
 
-    auto it = all_menus.find(argv[0]);
-    if (it != all_menus.end()) {
+    auto it = all_menus().find(argv[0]);
+    if (it != all_menus().end()) {
         it->second->enter();
     }
 
@@ -34,19 +40,20 @@ static int _cmd_enter_sub_menu(int argc, char **argv)
 
 // menu methods
 Menu::Menu(
-    const std::string &name, const std::string &cmd,
+    const etl::string<COMMAND_NAME_MAX_LENGTH> &name,
+    const etl::string<COMMAND_NAME_MAX_LENGTH> &cmd,
     Menu *parent, func_cb_t enter_cb) : name_(name), cmd_(cmd), parent_(parent)
 {
     enter_cb_ = enter_cb;
 
     if (cmd != "") {
-        assert(all_menus.count(cmd) == 0);
-        all_menus[cmd] = this;
+        assert(all_menus().count(cmd) == 0);
+        all_menus()[cmd] = this;
     }
 
-    std::string menu_desc = "Enter " + name;
     if (parent) {
-        parent->push_back(new Command(cmd, menu_desc, _cmd_enter_sub_menu));
+        enter_cmd_ = { cmd, name, _cmd_enter_sub_menu };
+        parent->push_back(&enter_cmd_);
     }
 }
 

--- a/sys/shell_menu/include/shell_menu/Command.hpp
+++ b/sys/shell_menu/include/shell_menu/Command.hpp
@@ -12,7 +12,7 @@
 #pragma once
 
 // System includes
-#include <string>
+#include <etl/string.h>
 
 // RIOT includes
 #include "shell.h"
@@ -44,24 +44,24 @@ public:
 
     /// Constructor.
     Command(
-        const std::string &name,         ///< [in] command name
-        const std::string &desc,         ///< [in] description to print in the "help" command
-        shell_command_handler_t handler  ///< [in] the callback function
+        const etl::string<COMMAND_NAME_MAX_LENGTH> &name = "",  ///< [in] command name
+        const etl::string<COMMAND_DESC_MAX_LENGTH> &desc = "",  ///< [in] description to print in the "help" command
+        shell_command_handler_t handler = nullptr               ///< [in] the callback function
         );
 
     ///Destructor.
     ~Command();
 
     /// Return the name of this command.
-    const std::string & name(void) const { return name_; };
+    const etl::string<COMMAND_NAME_MAX_LENGTH> & name(void) const { return name_; };
 
     /// Return the name of this menu.
     void set_name(
-        const std::string & name         ///< [in] new command name
+        const etl::string<COMMAND_NAME_MAX_LENGTH> & name         ///< [in] new command name
         ) { name_ = name; };
 
     /// Return the description of this command.
-    const std::string & desc(void) const { return desc_; };
+    const etl::string<COMMAND_DESC_MAX_LENGTH> & desc(void) const { return desc_; };
 
     /// Return the name of this command.
     shell_command_handler_t handler(void) const { return handler_; };
@@ -73,9 +73,9 @@ public:
     const PB_Message &pb_message(void) const { return pb_message_; };
 
 private:
-    std::string name_;                   ///< name of the command
-    std::string desc_;                   ///< description to print in the "help" command
-    shell_command_handler_t handler_;    ///< the callback function
+    etl::string<COMMAND_NAME_MAX_LENGTH> name_;  ///< name of the command
+    etl::string<COMMAND_DESC_MAX_LENGTH> desc_;  ///< description to print in the "help" command
+    shell_command_handler_t handler_;            ///< the callback function
     PB_Message pb_message_;
 };
 

--- a/sys/shell_menu/include/shell_menu/Menu.hpp
+++ b/sys/shell_menu/include/shell_menu/Menu.hpp
@@ -14,14 +14,18 @@
 #include "shell_menu/Command.hpp"
 
 // System includes
-#include <string>
-#include <list>
+#include <etl/list.h>
+#include <etl/string.h>
 
 // Project includes
 #include "utils.hpp"
 
 #ifndef NB_SHELL_COMMANDS
 #  define NB_SHELL_COMMANDS 20    ///< max shell commands per menu
+#endif
+
+#ifndef NB_SHELL_MENUS
+#  define NB_SHELL_MENUS 10       ///< max shell menus
 #endif
 
 namespace cogip {
@@ -33,21 +37,21 @@ namespace shell {
 /// It has a name and a command to enter it.
 /// A callback can be specified to be executed at menu entry.
 /// It is linked to its parent menu.
-class Menu : public std::list<Command *> {
+class Menu : public etl::list<Command *, NB_SHELL_COMMANDS> {
 public:
     /// Constructor.
     Menu(
-        const std::string &name,      ///< [in] name of the menu
-        const std::string &cmd,       ///< [in] command name to enter the menu
-        Menu *parent = nullptr,       ///< [in] parent menu (optional)
-        func_cb_t enter_cb = nullptr  ///< [in] callback function executed at menu entry (optional)
+        const etl::string<COMMAND_NAME_MAX_LENGTH> &name, ///< [in] name of the menu
+        const etl::string<COMMAND_NAME_MAX_LENGTH> &cmd,  ///< [in] command name to enter the menu
+        Menu *parent = nullptr,                           ///< [in] parent menu (optional)
+        func_cb_t enter_cb = nullptr                      ///< [in] callback function executed at menu entry (optional)
         );
 
     /// Enter this menu.
     void enter(void);
 
     /// Return the name of this menu.
-    const std::string & name(void) const { return name_; };
+    const etl::string<COMMAND_NAME_MAX_LENGTH> & name(void) const { return name_; };
 
     /// Return the parent of this menu.
     Menu * parent(void) const { return parent_; };
@@ -61,10 +65,11 @@ public:
 #endif
 
 private:
-    std::string name_;                ///< menu name
-    std::string cmd_;                 ///< command to enter this menu
-    Menu *parent_;                    ///< pointer to the parent menu
-    func_cb_t enter_cb_;              ///< function to execute at menu entry
+    etl::string<COMMAND_NAME_MAX_LENGTH> name_;  ///< menu name
+    etl::string<COMMAND_NAME_MAX_LENGTH> cmd_;   ///< command to enter this menu
+    Menu *parent_;                               ///< pointer to the parent menu
+    func_cb_t enter_cb_;                         ///< function to execute at menu entry
+    Command enter_cmd_;                          ///< command used to enter this menu
 };
 
 } // namespace shell

--- a/sys/shell_menu/include/shell_menu/shell_menu.hpp
+++ b/sys/shell_menu/include/shell_menu/shell_menu.hpp
@@ -25,13 +25,13 @@ namespace cogip {
 namespace shell {
 
 #ifdef MODULE_UARTPB
-inline constexpr uartpb::uuid_t command_uuid = 2168120333; ///< uuid for uartpb
-inline constexpr uartpb::uuid_t menu_uuid = 1485239280; ///< uuid for uartpb
+inline constexpr uartpb::uuid_t command_uuid = 2168120333;  ///< command uuid for uartpb
+inline constexpr uartpb::uuid_t menu_uuid = 1485239280;     ///< menu uuid for uartpb
 #endif
 
-extern Menu root_menu;            ///< root menu
-extern Menu *current_menu;        ///< pointer to the current menu
-extern std::list<Command *> global_commands;  ///< global commands, available in all menus
+Menu & root_menu();                                              ///< root menu
+extern Menu *current_menu;                                       ///< pointer to the current menu
+extern etl::list<Command *, NB_SHELL_COMMANDS> global_commands;  ///< global commands, available in all menus
 
 /// Start the main menu.
 void start(void);
@@ -43,8 +43,8 @@ void add_global_command(
 
 /// Rename a command.
 void rename_command(
-    const std::string &old_name,  ///< [in] old command name
-    const std::string &new_name   ///< [in] new command name
+    const etl::string<COMMAND_NAME_MAX_LENGTH> &old_name,  ///< [in] old command name
+    const etl::string<COMMAND_NAME_MAX_LENGTH> &new_name   ///< [in] new command name
     );
 
 #ifdef MODULE_UARTPB

--- a/sys/shell_menu/shell_menu_private.hpp
+++ b/sys/shell_menu/shell_menu_private.hpp
@@ -17,15 +17,16 @@
 #include "uartpb/UartProtobuf.hpp"
 #endif
 
-#include <map>
-#include <set>
+#include <etl/map.h>
+#include <etl/set.h>
+#include <array>
 
 namespace cogip {
 
 namespace shell {
 
-extern std::map<std::string, Menu *> all_menus;     ///< map containing all menus indexed by cmd
-extern std::set<Command *> all_commands;            ///< all commands
+etl::map<etl::string<COMMAND_NAME_MAX_LENGTH>, Menu *, NB_SHELL_MENUS> & all_menus();  ///< map containing all menus indexed by cmd
+etl::set<Command *, NB_SHELL_COMMANDS * NB_SHELL_MENUS> & all_commands();              ///< all commands
 
 #ifdef MODULE_UARTPB
 extern cogip::uartpb::UartProtobuf *uart_protobuf;  ///< UartProtocol instance used to send new menu over UART


### PR DESCRIPTION
Refactor code to only use strings and containers allocated at compile time.