### PR TITLE
boards: cogip-nucleo-f446re: split motor driver configuration

### DIFF
--- a/boards/cogip-nucleo-f446re/include/board.h
+++ b/boards/cogip-nucleo-f446re/include/board.h
@@ -74,7 +74,6 @@ extern "C" {
 
 /**
  * @brief Describe DC motor with PWM channel and GPIOs
- * @{
  */
 static const motor_driver_config_t motor_driver_config[] = {
     {
@@ -84,8 +83,9 @@ static const motor_driver_config_t motor_driver_config[] = {
         .pwm_mode = PWM_LEFT,
         .pwm_frequency = 20000U,
         .pwm_resolution = 1500U,
-        .nb_motors = 2,
+        .nb_motors = 1,
         .motors = {
+            /* Left motor */
             {
                 .pwm_channel = 2,
                 .gpio_enable = GPIO_PIN(PORT_A, 12),
@@ -95,6 +95,19 @@ static const motor_driver_config_t motor_driver_config[] = {
                 .gpio_enable_invert = 0,
                 .gpio_brake_invert = 0,
             },
+        },
+        .cb = NULL
+    },
+    {
+        .pwm_dev = 1,
+        .mode = MOTOR_DRIVER_2_DIRS,
+        .mode_brake = MOTOR_BRAKE_LOW,
+        .pwm_mode = PWM_LEFT,
+        .pwm_frequency = 20000U,
+        .pwm_resolution = 1500U,
+        .nb_motors = 1,
+        .motors = {
+            /* Right motor */
             {
                 .pwm_channel = 0,
                 .gpio_enable = GPIO_PIN(PORT_A, 11),

--- a/platforms/pegasus/lidar_obstacles.cpp
+++ b/platforms/pegasus/lidar_obstacles.cpp
@@ -18,7 +18,7 @@
 #define NB_ANGLES_WITHOUT_OBSACLE_TO_IGNORE 3
 
 // Periodic task
-#define TASK_PERIOD_USEC    (50 * US_PER_MS)
+#define TASK_PERIOD_USEC    (200 * US_PER_MS)
 
 // Thread priority
 #define OBSTACLE_UPDATER_PRIO (THREAD_PRIORITY_MAIN - 1)

--- a/platforms/pegasus/trace_utils.cpp
+++ b/platforms/pegasus/trace_utils.cpp
@@ -7,7 +7,7 @@
 #include "platform.hpp"
 
 /* Periodic task */
-#define TASK_PERIOD_USEC    (100 * US_PER_MS)
+#define TASK_PERIOD_USEC    (500 * US_PER_MS)
 
 /* Thread stack */
 static char trace_thread_stack[THREAD_STACKSIZE_MEDIUM];

--- a/platforms/pf_test/lidar_obstacles.cpp
+++ b/platforms/pf_test/lidar_obstacles.cpp
@@ -18,7 +18,7 @@
 #define NB_ANGLES_WITHOUT_OBSACLE_TO_IGNORE 3
 
 // Periodic task
-#define TASK_PERIOD_USEC    (50 * US_PER_MS)
+#define TASK_PERIOD_USEC    (200 * US_PER_MS)
 
 // Thread priority
 #define OBSTACLE_UPDATER_PRIO (THREAD_PRIORITY_MAIN - 1)

--- a/platforms/pf_test/trace_utils.cpp
+++ b/platforms/pf_test/trace_utils.cpp
@@ -7,7 +7,7 @@
 #include "platform.hpp"
 
 /* Periodic task */
-#define TASK_PERIOD_USEC    (100 * US_PER_MS)
+#define TASK_PERIOD_USEC    (500 * US_PER_MS)
 
 /* Thread stack */
 static char trace_thread_stack[THREAD_STACKSIZE_MEDIUM];


### PR DESCRIPTION
This commit introduces no functional changes.
Other boards are using different pwm devices for each motor and
have one hardware driver per motor.
To reproduce this configuration for consistency with other boards and
allow this board to be used in applications, split the dual motor driver
into two single motor drivers.
PWM device is configured twice in the same way which is acceptable.

Signed-off-by: Gilles DOFFE <g.doffe@gmail.com>