### PR TITLE
makefiles: fix RIOT patches application on specific application build

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -8,6 +8,9 @@ BUILD_DIR = $(BINDIR)/build
 PKGDIRBASE = $(BUILD_DIR)/pkg
 RIOTPKG ?= $(MCUFIRMWAREBASE)/pkg
 
+# Apply RIOT-OS patches as soon as possible
+include $(MCUFIRMWAREBASE)/makefiles/riot-patches.mk.inc
+
 # Create a symbolic for each package in RIOT
 pkgs := $(foreach dir,$(wildcard $(RIOTBASE)/pkg/*/Makefile),$(subst Makefile,, $(dir)))
 $(foreach pkg,$(pkgs), $(shell ln -sf $(pkg) $(RIOTPKG)/$(notdir $(pkg))))
@@ -92,6 +95,7 @@ ifeq (,$(findstring -DISR_STACKSIZE=,$(CFLAGS)))
 	CFLAGS += -DISR_STACKSIZE=2048
 endif
 
+all: $(patchstamps)
 .PHONY: world
 world: all
 	$(Q)$(MCUFIRMWAREBASE)/tools/fwsize.sh $(SIZE) $(ELFFILE) $(FLASHSIZE) $(RAM_LEN)

--- a/makefiles/riot-patches.mk.inc
+++ b/makefiles/riot-patches.mk.inc
@@ -1,0 +1,6 @@
+# List of patch stamp files
+patchstamps := $(addsuffix ed, $(realpath $(wildcard $(MCUFIRMWAREBASE)/riot-patches/*.patch)))
+
+%.patched: %.patch
+	@cd $(RIOTBASE) && quilt import $< && quilt push
+	@touch $@


### PR DESCRIPTION
If patches have never been applied and a specific application is built,
patches are not applied. For example:
  $ make -C applications/app_test

This commit fix this by adding patch target as a dependency for all apps
in Makefile.include.

Signed-off-by: Gilles DOFFE <g.doffe@gmail.com>