### PR TITLE
makefiles: check glibc version before use of mallinfo2

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -11,6 +11,9 @@ RIOTPKG ?= $(MCUFIRMWAREBASE)/pkg
 # Apply RIOT-OS patches as soon as possible
 include $(MCUFIRMWAREBASE)/makefiles/riot-patches.mk.inc
 
+# Function to check version
+include $(MCUFIRMWAREBASE)/makefiles/version_check.mk.inc
+
 # Create a symbolic for each package in RIOT
 pkgs := $(foreach dir,$(wildcard $(RIOTBASE)/pkg/*/Makefile),$(subst Makefile,, $(dir)))
 $(foreach pkg,$(pkgs), $(shell ln -sf $(pkg) $(RIOTPKG)/$(notdir $(pkg))))
@@ -82,8 +85,15 @@ ifneq ($(CPU),native)
 	.DEFAULT_GOAL := world
 endif
 
-# mallinfo2 is only available on native architecture making mallinfo deprecated
+# mallinfo2 is only available on native architecture with glibc >=2.33, making mallinfo deprecated
+mallinfo := mallinfo
 ifeq ($(CPU),native)
+	GLIBC_VERSION := $(shell ldd --version | head -1 | awk '{print $$NF}')
+	ifeq ($(call version_ge,$(GLIBC_VERSION),2.33),TRUE)
+		mallinfo := mallinfo2
+	endif
+endif
+ifeq ($(mallinfo), mallinfo2)
 	CFLAGS += -D"MALLINFO=struct mallinfo2"
 	CFLAGS += -D"MALLINFO_FUNC()=mallinfo2()"
 else

--- a/makefiles/version_check.mk.inc
+++ b/makefiles/version_check.mk.inc
@@ -1,0 +1,3 @@
+define version_ge
+$(findstring TRUE,$(shell bash -c 'sort -cu -t. -k1,1nr -k2,2nr -k3,3nr -k4,4nr <(echo -e "$2\n$1") 2>&1 || echo TRUE'))
+endef


### PR DESCRIPTION
The mallinfo2 structure and function were introduced in glibc 2.33. Thus check glibc version on native architecture to avoid undefined reference to mallinfo2.