### PR TITLE
makefiles: introduce Makefile.dep

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1,0 +1,12 @@
+# Required features
+FEATURES_REQUIRED += cpp
+FEATURES_REQUIRED += libstdcpp
+
+# Required modules
+USEMODULE += thread
+USEMODULE += ztimer_sec
+USEMODULE += ztimer_msec
+USEMODULE += ztimer_usec
+
+# Required packages
+USEPKG += etl

--- a/Makefile.include
+++ b/Makefile.include
@@ -23,19 +23,6 @@ QUIET ?= 1
 DEVELHELP ?= 1
 THREAD_NAMES = 1
 
-# Required features
-FEATURES_REQUIRED += cpp
-FEATURES_REQUIRED += libstdcpp
-
-# Required modules
-USEMODULE += thread
-USEMODULE += ztimer_sec
-USEMODULE += ztimer_msec
-USEMODULE += ztimer_usec
-
-# Required packages
-USEPKG += etl
-
 define remote-flash-recipe
 	scp $(BINFILE) $(REMOTE_USER)@$(REMOTE_TARGET):/tmp/fw.bin
 	$(GDB) -nx -batch -ex "target extended-remote $(REMOTE_TARGET):3333" -ex "monitor reset halt" -ex "monitor flash write_image erase /tmp/fw.bin 0x08000000" -ex "monitor reset run"
@@ -63,6 +50,9 @@ EXTERNAL_MODULE_DIRS += $(MCUFW_MODULE_DIRS:%=$(MCUFIRMWAREBASE)/%/) $(shell_mod
 
 # Export mcu-firmware global variables
 include $(MCUFIRMWAREBASE)/makefiles/global_vars.mk.inc
+
+# Global project requirements
+include $(MCUFIRMWAREBASE)/Makefile.dep
 
 # RIOT Makefile include
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
Feature, module and package depencies are listed in Makefile.include which is dirty and less readable.
Move them to Makefile.dep and include it in Makefile.include.