### PR TITLE
Split configuration of PIDs

### DIFF
--- a/lib/pid_ng/PB_Pid.proto
+++ b/lib/pid_ng/PB_Pid.proto
@@ -12,6 +12,6 @@ message PB_Pid {
     double integral_term_limit = 7;
 }
 
-message PB_Pids {
-    repeated PB_Pid pids = 1;
+message PB_Pid_Id {
+    PB_PidEnum id = 1;
 }


### PR DESCRIPTION
Instead of configuring PIDs using only one message for all, use a single message of each PID.
This is required to reduce PID Protobuf messages to fit into a CAN frame.