### PR TITLE
platform engine: replace callbacks by object references

### DIFF
--- a/motion_control/engines/platform_engine/Makefile.dep
+++ b/motion_control/engines/platform_engine/Makefile.dep
@@ -1,4 +1,5 @@
 USEMODULE += motion_control_common
+USEMODULE += drive_controller
 USEMODULE += cogip_defs
 USEMODULE += path
 USEMODULE += thread

--- a/motion_control/engines/platform_engine/PlatformEngine.cpp
+++ b/motion_control/engines/platform_engine/PlatformEngine.cpp
@@ -18,15 +18,15 @@ namespace motion_control {
 
 void PlatformEngine::prepare_inputs() {
     // Update current pose and speed
-    platform_get_speed_and_pose_cb_(current_speed_, current_pose_);
+    odometer_.update();
 
     if (controller_) {
         size_t index = 0;
 
         // Current pose
-        controller_->set_input(index++, current_pose_.x());
-        controller_->set_input(index++, current_pose_.y());
-        controller_->set_input(index++, current_pose_.O());
+        controller_->set_input(index++, odometer_.pose().x());
+        controller_->set_input(index++, odometer_.pose().y());
+        controller_->set_input(index++, odometer_.pose().O());
 
         // Target pose
         controller_->set_input(index++, target_pose_.x());
@@ -34,8 +34,8 @@ void PlatformEngine::prepare_inputs() {
         controller_->set_input(index++, target_pose_.O());
 
         // Current speed
-        controller_->set_input(index++, current_speed_.distance());
-        controller_->set_input(index++, current_speed_.angle());
+        controller_->set_input(index++, odometer_.delta_polar_pose().distance());
+        controller_->set_input(index++, odometer_.delta_polar_pose().angle());
 
         // Target speed
         controller_->set_input(index++, target_speed_.distance());
@@ -60,7 +60,11 @@ void PlatformEngine::process_outputs() {
         controller_->output(1)
     );
 
-    platform_process_commands_cb_(command);
+    // Set robot polar velocity order
+    drive_contoller_.set_polar_velocity(command);
+
+    // Dispatch pose reached state
+    pose_reached_cb_(pose_reached_);
 };
 
 } // namespace motion_control


### PR DESCRIPTION
Replace legacy callbacks by odometer and drive controller interfaces references.

This allows to use polymorphism in order to make platform engine work with any kind of odometer and drive controller type.

Add a new callback in order to dispatch pose reached state.