### PR TITLE
motion control: fix PassthroughPosePIDController parameters number

### DIFF
--- a/motion_control/controllers/passthrough_pose_pid_controller/PassthroughPosePIDController.cpp
+++ b/motion_control/controllers/passthrough_pose_pid_controller/PassthroughPosePIDController.cpp
@@ -41,6 +41,8 @@ void PassthroughPosePIDController::execute() {
     this->outputs_[2] = parameters_->target_speed();
     // Store disabling speed filter (pass through)
     this->outputs_[3] = this->inputs_[3];
+    // Pose reached (pass through)
+    this->outputs_[4] = this->inputs_[4];
 };
 
 } // namespace motion_control

--- a/motion_control/controllers/passthrough_pose_pid_controller/include/passthrough_pose_pid_controller/PassthroughPosePIDController.hpp
+++ b/motion_control/controllers/passthrough_pose_pid_controller/include/passthrough_pose_pid_controller/PassthroughPosePIDController.hpp
@@ -24,10 +24,14 @@ namespace motion_control {
 /// Input 0:    polar pose error
 /// Input 1:    current speed
 /// Input 2:    target speed
+/// Input 3:    filter speed bool
+/// Input 4:    pose reached
 /// Output 0:   speed order
 /// Output 1:   current speed
 /// Output 2:   target speed
-class PassthroughPosePIDController : public Controller<4, 4, PassthroughPosePIDControllerParameters> {
+/// Output 3:   filter speed bool
+/// Output 4:   pose reached
+class PassthroughPosePIDController : public Controller<5, 5, PassthroughPosePIDControllerParameters> {
 public:
     /// Constructor
     explicit PassthroughPosePIDController(


### PR DESCRIPTION
The DualPIDMetaController took 5 parameter, and the SpeedFilter took 5 inputs parameters. So, the PassthroughPosePIDController should input and output the same number of parameters in order to be inserted in the DualPID meta controller.