### PR TITLE
187 change all doubles for floats

### DIFF
--- a/applications/cup2024-robot-motors/include/real/app_conf.hpp
+++ b/applications/cup2024-robot-motors/include/real/app_conf.hpp
@@ -4,18 +4,18 @@
 #include "etl/numeric.h"
 
 // Motor lift pose PID
-constexpr double motor_lift_pose_pid_kp = 1;
-constexpr double motor_lift_pose_pid_ki = 0;
-constexpr double motor_lift_pose_pid_kd = 0;
+constexpr float motor_lift_pose_pid_kp = 1;
+constexpr float motor_lift_pose_pid_ki = 0;
+constexpr float motor_lift_pose_pid_kd = 0;
 // Motor lift speed PID
-constexpr double motor_lift_speed_pid_kp = 200;
-constexpr double motor_lift_speed_pid_ki = 75;
-constexpr double motor_lift_speed_pid_kd = 0;
+constexpr float motor_lift_speed_pid_kp = 200;
+constexpr float motor_lift_speed_pid_ki = 75;
+constexpr float motor_lift_speed_pid_kd = 0;
 
 // Motor lift pose PID integral limit
-constexpr double motor_lift_pose_pid_integral_limit = etl::numeric_limits<int16_t>::max();
+constexpr float motor_lift_pose_pid_integral_limit = etl::numeric_limits<int16_t>::max();
 // Motor lift speed PID integral limit
-constexpr double motor_lift_speed_pid_integral_limit = 500 / 75; // (PWM resolution / Ki)
+constexpr float motor_lift_speed_pid_integral_limit = 500 / 75; // (PWM resolution / Ki)
 
 // Motor lift threshold
-constexpr double motor_lift_threshold = 0.1;
+constexpr float motor_lift_threshold = 0.1;

--- a/applications/cup2024-robot-motors/include/simulation/app_conf.hpp
+++ b/applications/cup2024-robot-motors/include/simulation/app_conf.hpp
@@ -4,18 +4,18 @@
 #include "etl/numeric.h"
 
 // Motor lift pose PID
-constexpr double motor_lift_pose_pid_kp = 1;
-constexpr double motor_lift_pose_pid_ki = 0;
-constexpr double motor_lift_pose_pid_kd = 0;
+constexpr float motor_lift_pose_pid_kp = 1;
+constexpr float motor_lift_pose_pid_ki = 0;
+constexpr float motor_lift_pose_pid_kd = 0;
 // Motor lift speed PID
-constexpr double motor_lift_speed_pid_kp = 200;
-constexpr double motor_lift_speed_pid_ki = 75;
-constexpr double motor_lift_speed_pid_kd = 0;
+constexpr float motor_lift_speed_pid_kp = 200;
+constexpr float motor_lift_speed_pid_ki = 75;
+constexpr float motor_lift_speed_pid_kd = 0;
 
 // Motor lift pose PID integral limit
-constexpr double motor_lift_pose_pid_integral_limit = etl::numeric_limits<int16_t>::max();
+constexpr float motor_lift_pose_pid_integral_limit = etl::numeric_limits<int16_t>::max();
 // Motor lift speed PID integral limit
-constexpr double motor_lift_speed_pid_integral_limit = 500 / 75; // (PWM resolution / Ki)
+constexpr float motor_lift_speed_pid_integral_limit = 500 / 75; // (PWM resolution / Ki)
 
 // Motor lift threshold
-constexpr double motor_lift_threshold = 0.1;
+constexpr float motor_lift_threshold = 0.1;

--- a/examples/motion_control_robot_test/include/motion_control.hpp
+++ b/examples/motion_control_robot_test/include/motion_control.hpp
@@ -14,20 +14,20 @@ constexpr uint16_t motion_control_thread_period_ms = 20;    ///< controller thre
 /// @name Acceleration and speed profiles
 /// @{
 // Linear maximum speed and acceleration
-constexpr double platform_max_speed_m_per_s = 1;  ///< Maximum speed (m/s)
-constexpr double platform_max_speed_linear_mm_per_period = (
+constexpr float platform_max_speed_m_per_s = 1;  ///< Maximum speed (m/s)
+constexpr float platform_max_speed_linear_mm_per_period = (
     (1000 * platform_max_speed_m_per_s * motion_control_thread_period_ms) \
     / 1000);    ///< Maximum linear speed (mm/<motion_control_thread_period_ms>)
-constexpr double platform_normal_speed_linear_mm_per_period = (2 * platform_max_speed_linear_mm_per_period) / 3;
-constexpr double platform_low_speed_linear_mm_per_period = platform_max_speed_linear_mm_per_period / 3;
+constexpr float platform_normal_speed_linear_mm_per_period = (2 * platform_max_speed_linear_mm_per_period) / 3;
+constexpr float platform_low_speed_linear_mm_per_period = platform_max_speed_linear_mm_per_period / 3;
 
 // Angular maximum speed and acceleration
-constexpr double platform_max_speed_deg_per_s = 720; ///< Maximum speed (deg/s)
-constexpr double platform_max_speed_angular_deg_per_period = (
+constexpr float platform_max_speed_deg_per_s = 720; ///< Maximum speed (deg/s)
+constexpr float platform_max_speed_angular_deg_per_period = (
     (platform_max_speed_deg_per_s * motion_control_thread_period_ms) \
     / 1000);    ///< Maximum angular speed (deg/<motion_control_thread_period_ms>)
-constexpr double platform_normal_speed_angular_deg_per_period = (2 * platform_max_speed_angular_deg_per_period) / 3;
-constexpr double platform_low_speed_angular_deg_per_period = platform_max_speed_angular_deg_per_period / 3;
+constexpr float platform_normal_speed_angular_deg_per_period = (2 * platform_max_speed_angular_deg_per_period) / 3;
+constexpr float platform_low_speed_angular_deg_per_period = platform_max_speed_angular_deg_per_period / 3;
 /// @}
 
 } // namespace actuators

--- a/lib/cogip_defs/Coords.cpp
+++ b/lib/cogip_defs/Coords.cpp
@@ -7,7 +7,7 @@ namespace cogip {
 
 namespace cogip_defs {
 
-double Coords::distance(const Coords &dest) const
+float Coords::distance(const Coords &dest) const
 {
     return sqrt((dest.x_ - x_) * (dest.x_ - x_)
                 + (dest.y_ - y_) * (dest.y_ - y_));

--- a/lib/cogip_defs/include/cogip_defs/Coords.hpp
+++ b/lib/cogip_defs/include/cogip_defs/Coords.hpp
@@ -22,31 +22,31 @@ class Coords {
 public:
     /// Constructor.
     Coords(
-        double x=0.0,       ///< [in] X coordinate
-        double y=0.0        ///< [in] Y coordinate
+        float x=0.0,       ///< [in] X coordinate
+        float y=0.0        ///< [in] Y coordinate
         ) : x_(x), y_(y) {};
 
     /// Constructor from Protobuf class
     explicit Coords(const PB_Coords &coords) : x_(coords.get_x()), y_(coords.get_y()) {};
 
     /// Return X coordinate.
-    double x(void) const { return x_; };
+    float x(void) const { return x_; };
 
     /// Return Y coordinate.
-    double y(void) const { return y_; };
+    float y(void) const { return y_; };
 
     /// Set X coordinate.
     void set_x(
-        double x            ///< [in] new X coordinate
+        float x            ///< [in] new X coordinate
         ) { x_ = x; };
 
     /// Set Y coordinate.
     void set_y(
-        double y            ///< [in] new Y coordinate
+        float y            ///< [in] new Y coordinate
         ) { y_ = y; };
 
     /// Compute the distance the destination point.
-    double distance(
+    float distance(
         const Coords &dest  ///< [in] destination
         ) const;
 
@@ -72,8 +72,8 @@ public:
     };
 
 protected:
-    double x_;              ///< x-position
-    double y_;              ///< y-position
+    float x_;              ///< x-position
+    float y_;              ///< y-position
 };
 
 } // namespace cogip_defs

--- a/lib/cogip_defs/include/cogip_defs/Polar.hpp
+++ b/lib/cogip_defs/include/cogip_defs/Polar.hpp
@@ -22,8 +22,8 @@ class Polar {
 public:
     /// Constructor.
     Polar(
-        double distance = 0.0, ///< [in] distance
-        double angle = 0.0     ///< [in] angle
+        float distance = 0.0, ///< [in] distance
+        float angle = 0.0     ///< [in] angle
         ) : distance_(distance), angle_(angle) {};
 
     /// Constructor from Protobuf class
@@ -32,19 +32,19 @@ public:
         angle_(polar.get_angle()) {};
 
     /// Return distance.
-    double distance(void) const { return distance_; };
+    float distance(void) const { return distance_; };
 
     /// Return angle.
-    double angle(void) const { return angle_; };
+    float angle(void) const { return angle_; };
 
     /// Set distance.
     void set_distance(
-        double distance        ///< [in] new distance
+        float distance        ///< [in] new distance
         ) { distance_ = distance; };
 
     /// Set angle.
     void set_angle(
-        double angle           ///< [in] new angle
+        float angle           ///< [in] new angle
         ) { angle_ = angle; };
 
     /// Copy data to Protobuf message.
@@ -77,8 +77,8 @@ public:
     };
 
 private:
-    double distance_;          ///< distance
-    double angle_;             ///< angle
+    float distance_;          ///< distance
+    float angle_;             ///< angle
 };
 
 } // namespace cogip_defs

--- a/lib/cogip_defs/include/cogip_defs/Pose.hpp
+++ b/lib/cogip_defs/include/cogip_defs/Pose.hpp
@@ -25,9 +25,9 @@ class Pose : public Coords {
 public:
     /// Constructor.
     Pose(
-        double x=0.0,         ///< [in] X coordinate
-        double y=0.0,         ///< [in] Y coordinate
-        double O=0.0          ///< [in] 0-orientation
+        float x=0.0,         ///< [in] X coordinate
+        float y=0.0,         ///< [in] Y coordinate
+        float O=0.0          ///< [in] 0-orientation
         ) : Coords(x, y), O_(O) {};
 
     /// Constructor from Protobuf class
@@ -42,11 +42,11 @@ public:
         ) { x_ = coords.x(); y_ = coords.y();};
 
     /// Return 0-orientation.
-    double O(void) const { return O_; };
+    float O(void) const { return O_; };
 
     /// Set 0-orientation.
     void set_O(
-        double O              ///< [in] new 0-orientation
+        float O              ///< [in] new 0-orientation
         ) { O_ = O; };
 
     /// Check if this pose is equal to another.
@@ -65,10 +65,10 @@ public:
     };
 
     Polar operator-(const Pose& p) {
-        double error_x = x_ - p.x();
-        double error_y = y_ - p.y();
+        float error_x = x_ - p.x();
+        float error_y = y_ - p.y();
 
-        double error_O = limit_angle_rad(atan2(error_y, error_x) - DEG2RAD(p.O()));
+        float error_O = limit_angle_rad(atan2(error_y, error_x) - DEG2RAD(p.O()));
 
         return Polar(
             sqrt(square(error_x) + square(error_y)),
@@ -77,7 +77,7 @@ public:
     };
 
 protected:
-    double O_;                ///< 0-orientation
+    float O_;                ///< 0-orientation
 };
 
 } // namespace cogip_defs

--- a/lib/encoder/include/encoder/EncoderInterface.hpp
+++ b/lib/encoder/include/encoder/EncoderInterface.hpp
@@ -55,9 +55,9 @@ public:
     /// 
     /// @brief Get the angle measured by the encoder since the last call.
     ///
-    /// @return double traveled angle since last call (rad).
+    /// @return float traveled angle since last call (rad).
     ///
-    double get_angle_and_reset() { return ((double)read_and_reset() / (double)pulse_per_rev_) * etl::math::pi; }
+    float get_angle_and_reset() { return ((float)read_and_reset() / (float)pulse_per_rev_) * etl::math::pi; }
 
 protected:
     const EncoderMode mode_;

--- a/lib/motor/include/motor/MotorDriverDRV8873.hpp
+++ b/lib/motor/include/motor/MotorDriverDRV8873.hpp
@@ -21,7 +21,7 @@ public:
     /// @brief Set motor speed
     /// @param speed speed in % [-100; 100]
     /// @return  0 on success, negative on error
-    int set_speed(double speed, int id) override
+    int set_speed(float speed, int id) override
     {
         // WORKAROUND for H-Bridge TI DRV8873HPWPRQ1, need to reset fault in case of undervoltage
         disable(id);

--- a/lib/motor/include/motor/MotorDriverInterface.hpp
+++ b/lib/motor/include/motor/MotorDriverInterface.hpp
@@ -33,7 +33,7 @@ public:
     /// @param speed speed in % [-100; 100]
     /// @param id id of the motor
     /// @return  0 on success, negative on error
-    virtual int set_speed(double speed, int id) = 0;
+    virtual int set_speed(float speed, int id) = 0;
 
     /// @brief break the motor
     /// @param id id of the motor

--- a/lib/motor/include/motor/MotorDriverRIOT.hpp
+++ b/lib/motor/include/motor/MotorDriverRIOT.hpp
@@ -55,14 +55,14 @@ public:
     /// @param speed speed in % [-100; 100]
     /// @param id id of the motor
     /// @return  0 on success, negative on error
-    int set_speed(double speed, int id) override
+    int set_speed(float speed, int id) override
     {
         // Convert speed in percent to pwm value
-        double pwm_value = (speed * (double)parameters_.pwm_resolution) / 100.0;
+        float pwm_value = (speed * (float)parameters_.pwm_resolution) / 100.0;
 
         // limit pwm value in order to ensure range between [-parameters_.pwm_resolution;parameters_.pwm_resolution]
-        if (fabs(pwm_value) > (double)parameters_.pwm_resolution) {
-            pwm_value = (speed < 0.0 ? -1.0 : 1.0) * (double)parameters_.pwm_resolution;
+        if (fabs(pwm_value) > (float)parameters_.pwm_resolution) {
+            pwm_value = (speed < 0.0 ? -1.0 : 1.0) * (float)parameters_.pwm_resolution;
         }
 
         return motor_set(&driver_, id, (int32_t)pwm_value);

--- a/lib/motor/include/motor/MotorInterface.hpp
+++ b/lib/motor/include/motor/MotorInterface.hpp
@@ -22,7 +22,7 @@ public:
     /// @brief Set motor speed
     /// @param speed speed in % [-100; 100]
     /// @return  0 on success, negative on error
-    virtual int set_speed(double speed) = 0;
+    virtual int set_speed(float speed) = 0;
 
     /// @brief break the motor
     /// @return 0 on success, negative on error

--- a/lib/motor/include/motor/MotorRIOT.hpp
+++ b/lib/motor/include/motor/MotorRIOT.hpp
@@ -30,7 +30,7 @@ public:
     /// @brief Set motor speed
     /// @param speed speed in % [-100; 100]
     /// @return  0 on success, negative on error
-    int set_speed(double speed)
+    int set_speed(float speed)
     {
         return driver_.set_speed(speed, id_);
     }

--- a/lib/odometry-ng/OdometerDifferential.cpp
+++ b/lib/odometry-ng/OdometerDifferential.cpp
@@ -11,17 +11,17 @@ namespace odometer {
 int OdometerDifferential::update()
 {
     // Compute encoders wheels left and right linear delta in mm
-    const double dL = left_encoder_.get_angle_and_reset() * parameters_.left_wheel_diameter_mm() * parameters_.left_polarity();
-    const double dR = right_encoder_.get_angle_and_reset() * parameters_.right_wheel_diameter_mm() * parameters_.right_polarity();
+    const float dL = left_encoder_.get_angle_and_reset() * parameters_.left_wheel_diameter_mm() * parameters_.left_polarity();
+    const float dR = right_encoder_.get_angle_and_reset() * parameters_.right_wheel_diameter_mm() * parameters_.right_polarity();
 
     // Compute linear delta for robot in mm
-    const double delta_linear_pose      = (dL + dR) / 2;
+    const float delta_linear_pose      = (dL + dR) / 2;
 
     // Compute angular delta for robot in rad
-    const double delta_angular_pose      = (dR - dL) / parameters_.track_width_mm();
+    const float delta_angular_pose      = (dR - dL) / parameters_.track_width_mm();
 
     // Compute angle in rad between -pi and pi
-    double O_rad = DEG2RAD(pose_.O());
+    float O_rad = DEG2RAD(pose_.O());
     O_rad = limit_angle_rad(O_rad + delta_angular_pose);
     
     // Compute x and y coordinates in mm

--- a/lib/odometry-ng/include/odometer/OdometerDifferential.hpp
+++ b/lib/odometry-ng/include/odometer/OdometerDifferential.hpp
@@ -27,7 +27,7 @@ public:
     /// @param x X coordinate (mm)
     /// @param y Y coordinate (mm)
     /// @param O angle (deg)
-    void set_pose(double x, double y, double O) override
+    void set_pose(float x, float y, float O) override
     {
         pose_.set_x(x);
         pose_.set_y(y);

--- a/lib/odometry-ng/include/odometer/OdometerDifferentialParameters.hpp
+++ b/lib/odometry-ng/include/odometer/OdometerDifferentialParameters.hpp
@@ -12,55 +12,55 @@ public:
     /// @param track_width Track width value (mm)
     /// @param left_polarity left wheel polarity no unit, 1 or -1
     /// @param right_polarity riht wheel polarity no unit, 1 or -1
-    OdometerDifferentialParameters(double left_wheel_diameter, 
-    double right_wheel_diameter, double track_width, double left_polarity, double right_polarity) : left_wheel_diameter_(left_wheel_diameter), right_wheel_diameter_(right_wheel_diameter), track_width_(track_width), left_polarity_(left_polarity), right_polarity_(right_polarity) {};
+    OdometerDifferentialParameters(float left_wheel_diameter, 
+    float right_wheel_diameter, float track_width, float left_polarity, float right_polarity) : left_wheel_diameter_(left_wheel_diameter), right_wheel_diameter_(right_wheel_diameter), track_width_(track_width), left_polarity_(left_polarity), right_polarity_(right_polarity) {};
 
     /// @brief Set the left encoder wheel diameter dimension
     /// @param wheel_diameter Wheel diameter value (mm)
-    void set_left_wheel_diameter(double wheel_diameter) { left_wheel_diameter_ = wheel_diameter; }
+    void set_left_wheel_diameter(float wheel_diameter) { left_wheel_diameter_ = wheel_diameter; }
 
     /// @brief Return left encoder wheel diameter value in mm.
-    /// @return double Wheel diameter value (mm)
-    double left_wheel_diameter_mm() const { return left_wheel_diameter_; }
+    /// @return float Wheel diameter value (mm)
+    float left_wheel_diameter_mm() const { return left_wheel_diameter_; }
 
     /// @brief Set the right wheel encoder diameter dimension
     /// @param wheel_diameter Wheel diameter value (mm)
-    void set_right_wheel_diameter(double wheel_diameter) { right_wheel_diameter_ = wheel_diameter; }
+    void set_right_wheel_diameter(float wheel_diameter) { right_wheel_diameter_ = wheel_diameter; }
 
     /// @brief Return right encoder wheel diameter value in mm.
-    /// @return double Wheel diameter value (mm)
-    double right_wheel_diameter_mm() const { return right_wheel_diameter_; }
+    /// @return float Wheel diameter value (mm)
+    float right_wheel_diameter_mm() const { return right_wheel_diameter_; }
 
     /// @brief Set the axle track dimension
     /// @param track_width Track width value (mm)
-    void set_track_width(double track_width) { track_width_ = track_width; }
+    void set_track_width(float track_width) { track_width_ = track_width; }
 
     /// @brief Get the axle track value
-    /// @return double Track width value (mm)
-    double track_width_mm() const { return track_width_; }
+    /// @return float Track width value (mm)
+    float track_width_mm() const { return track_width_; }
 
     /// @brief Set the left encoder polarity
     /// @param polarity Encoder polarity. -1 or 1.
-    void set_left_polarity(double polarity) { left_polarity_ = polarity; }
+    void set_left_polarity(float polarity) { left_polarity_ = polarity; }
 
     /// @brief Get the left encoder polarity
-    /// @return double Encoder polarity. -1 or 1
-    double left_polarity() const { return left_polarity_; }
+    /// @return float Encoder polarity. -1 or 1
+    float left_polarity() const { return left_polarity_; }
 
     /// @brief Set the right encoder polarity
     /// @param polarity Encoder polarity. -1 or 1.
-    void set_right_polarity(double polarity) { right_polarity_ = polarity; }
+    void set_right_polarity(float polarity) { right_polarity_ = polarity; }
 
     /// @brief Get the right encoder polarity
-    /// @return double Encoder polarity. -1 or 1
-    double right_polarity() const { return right_polarity_; }
+    /// @return float Encoder polarity. -1 or 1
+    float right_polarity() const { return right_polarity_; }
 
 private:
-    double left_wheel_diameter_;
-    double right_wheel_diameter_;
-    double track_width_;
-    double left_polarity_;
-    double right_polarity_;
+    float left_wheel_diameter_;
+    float right_wheel_diameter_;
+    float track_width_;
+    float left_polarity_;
+    float right_polarity_;
 };
 
 } // namespace odometer

--- a/lib/odometry-ng/include/odometer/OdometerInterface.hpp
+++ b/lib/odometry-ng/include/odometer/OdometerInterface.hpp
@@ -18,7 +18,7 @@ public:
     /// @param x X coordinate (mm)
     /// @param y Y coordinate (mm)
     /// @param O angle (deg)
-    virtual void set_pose(double x, double y, double O) = 0;
+    virtual void set_pose(float x, float y, float O) = 0;
 
     /// @brief Set the default odometry pose
     ///

--- a/lib/odometry/include/odometry.hpp
+++ b/lib/odometry/include/odometry.hpp
@@ -13,7 +13,7 @@
  * \brief odometry wheels_distance setup
  * \param d : distance between wheels [pulse]
  */
-void odometry_setup(double d);
+void odometry_setup(float d);
 
 /**
  * \fn odometry_update

--- a/lib/odometry/odometry.cpp
+++ b/lib/odometry/odometry.cpp
@@ -6,16 +6,16 @@
 #include "utils.hpp"
 
 /**
- * \fn void odometry_by_segment (const double distance, const double angle)
+ * \fn void odometry_by_segment (const float distance, const float angle)
  * \brief update new robot pose (x, y, O) approximated by straight line
  *		segments
  * \param distance : delta value for distance [pulse]
  * \param angle : delta value for angle [pulse]
  */
 static void
-odometry_by_segment(cogip::cogip_defs::Pose &p, const double distance, const double angle)
+odometry_by_segment(cogip::cogip_defs::Pose &p, const float distance, const float angle)
 {
-    double O_rad;
+    float O_rad;
 
     O_rad = DEG2RAD(p.O());
 
@@ -25,15 +25,15 @@ odometry_by_segment(cogip::cogip_defs::Pose &p, const double distance, const dou
 }
 
 /**
- * \fn void odometry_by_arc (const double distance, const double angle)
+ * \fn void odometry_by_arc (const float distance, const float angle)
  * \brief update new robot pose (x, y, O) approximated by an arc
  * \param distance : delta value for distance [pulse]
  * \param angle : delta value for angle [pulse]
  */
 static void
-odometry_by_arc(cogip::cogip_defs::Pose &p, const double distance, const double angle)
+odometry_by_arc(cogip::cogip_defs::Pose &p, const float distance, const float angle)
 {
-    double O_rad;
+    float O_rad;
 
     O_rad = DEG2RAD(p.O());
 
@@ -44,12 +44,12 @@ odometry_by_arc(cogip::cogip_defs::Pose &p, const double distance, const double 
     }
     else {
         /* radius and angle of the arc */
-        double a = DEG2RAD(angle);
-        double r = distance / a;
+        float a = DEG2RAD(angle);
+        float r = distance / a;
 
         /* coordinates of the center of the arc */
-        double xo = p.x() - r * sin(O_rad);
-        double yo = p.y() + r * cos(O_rad);
+        float xo = p.x() - r * sin(O_rad);
+        float yo = p.y() + r * cos(O_rad);
 
         /* robot pose */
         p.set_O(limit_angle_deg(p.O() + angle));

--- a/lib/path/Pose.cpp
+++ b/lib/path/Pose.cpp
@@ -7,8 +7,8 @@ namespace cogip {
 namespace path {
 
 Pose::Pose(
-    double x, double y, double O,
-    double max_speed_ratio_linear, double max_speed_ratio_angular,
+    float x, float y, float O,
+    float max_speed_ratio_linear, float max_speed_ratio_angular,
     bool allow_reverse, bool bypass_anti_blocking, uint32_t timeout_ms,
     bool bypass_final_orientation
     ) : cogip_defs::Pose(x, y, O), allow_reverse_(allow_reverse),
@@ -16,8 +16,8 @@ Pose::Pose(
     bypass_final_orientation_(bypass_final_orientation)
 {
     // Ratios are betwen 0 and 1
-    max_speed_ratio_linear_ =  std::min(max_speed_ratio_linear, 1.);
-    max_speed_ratio_angular_ = std::min(max_speed_ratio_angular, 1.);
+    max_speed_ratio_linear_ =  std::min(max_speed_ratio_linear, 1.0f);
+    max_speed_ratio_angular_ = std::min(max_speed_ratio_angular, 1.0f);
 }
 
 void Pose::pb_read(const PB_PathPose &path_pose)

--- a/lib/path/include/path/Pose.hpp
+++ b/lib/path/include/path/Pose.hpp
@@ -25,11 +25,11 @@ class Pose : public cogip_defs::Pose {
 public:
     /// Constuctor.
     Pose(
-        double x=0.0,                   ///< [in] X coordinate
-        double y=0.0,                   ///< [in] Y coodinate
-        double O=0.0,                   ///< [in] 0-orientation
-        double max_speed_ratio_linear=0.0,  ///< [in] max speed linear
-        double max_speed_ratio_angular=0.0, ///< [in] max speed angular
+        float x=0.0,                   ///< [in] X coordinate
+        float y=0.0,                   ///< [in] Y coodinate
+        float O=0.0,                   ///< [in] 0-orientation
+        float max_speed_ratio_linear=0.0,  ///< [in] max speed linear
+        float max_speed_ratio_angular=0.0, ///< [in] max speed angular
         bool allow_reverse=true,        ///< [in] reverse mode
         bool bypass_antiblocking=false, ///< [in] bypass anti blocking
         uint32_t timeout_ms=0,          ///< [in] move timeout
@@ -40,10 +40,10 @@ public:
     virtual ~Pose() {};
 
     /// Return max speed linear.
-    virtual double max_speed_ratio_linear() const { return max_speed_ratio_linear_; };
+    virtual float max_speed_ratio_linear() const { return max_speed_ratio_linear_; };
 
     /// Return max speed angular.
-    virtual double max_speed_ratio_angular() const { return max_speed_ratio_angular_; };
+    virtual float max_speed_ratio_angular() const { return max_speed_ratio_angular_; };
 
     /// Is reverse mode allowed or not.
     virtual bool allow_reverse() const { return allow_reverse_; };
@@ -88,8 +88,8 @@ public:
     };
 
 private:
-    double max_speed_ratio_linear_; ///< max speed
-    double max_speed_ratio_angular_;///< max speed
+    float max_speed_ratio_linear_; ///< max speed
+    float max_speed_ratio_angular_;///< max speed
     bool allow_reverse_;            ///< reverse mode
     bool bypass_anti_blocking_;     ///< bypass anti blocking
     uint32_t timeout_ms_;           ///< timeout(ms) to reach the path pose

--- a/lib/pid/PID.cpp
+++ b/lib/pid/PID.cpp
@@ -5,9 +5,9 @@ namespace cogip {
 
 namespace pid {
 
-double PID::compute(double error)
+float PID::compute(float error)
 {
-    double p, i, d;
+    float p, i, d;
 
     // Integral term is the error sum
     integral_term_ += error;

--- a/lib/pid/include/pid/PID.hpp
+++ b/lib/pid/include/pid/PID.hpp
@@ -24,55 +24,55 @@ class PID {
 public:
     /// Constructor.
     PID(
-        double kp = 0.0,                                                ///< [in] proportional gain
-        double ki = 0.0,                                                ///< [in] integral gain
-        double kd = 0.0,                                                ///< [in] derivative gain
-        double integral_term_limit = etl::numeric_limits<double>::max() ///< [in] integral term limit
+        float kp = 0.0,                                                ///< [in] proportional gain
+        float ki = 0.0,                                                ///< [in] integral gain
+        float kd = 0.0,                                                ///< [in] derivative gain
+        float integral_term_limit = etl::numeric_limits<float>::max() ///< [in] integral term limit
     ) : kp_(kp), ki_(ki), kd_(kd), integral_term_(0), integral_term_limit_(integral_term_limit), previous_error_(0) {};
 
     /// Return proportional gain.
-    double kp() const { return kp_; };
+    float kp() const { return kp_; };
 
     /// Return integral gain.
-    double ki() const { return ki_; };
+    float ki() const { return ki_; };
 
     /// Return derivative gain.
-    double kd() const { return kd_; };
+    float kd() const { return kd_; };
 
     /// Return integral term.
-    double integral_term() const { return integral_term_; };
+    float integral_term() const { return integral_term_; };
 
     /// Return integral term limit.
-    double integral_term_limit() const { return integral_term_limit_; };
+    float integral_term_limit() const { return integral_term_limit_; };
 
     /// Set proportional gain.
     void set_kp(
-        double kp   ///< [in] new proportional gain
+        float kp   ///< [in] new proportional gain
         ) { kp_ = kp; };
 
     /// Set integral gain.
     void set_ki(
-        double ki   ///< [in] new integral gain
+        float ki   ///< [in] new integral gain
         ) { ki_ = ki; };
 
     /// Set derivative gain.
     void set_kd(
-        double kd   ///< [in] new derivative gain
+        float kd   ///< [in] new derivative gain
         ) { kd_ = kd; };
 
     /// Set integral term limit.
     void set_integral_term_limit(
-        double integral_term_limit  ///< [in] new integral term limit
+        float integral_term_limit  ///< [in] new integral term limit
         ) { integral_term_limit_ = integral_term_limit; };
 
     /// Return previous error.
-    double previous_error() const { return previous_error_; };
+    float previous_error() const { return previous_error_; };
 
     /// Reset integral term and previous_error.
     void reset() { integral_term_ = 0; previous_error_ = 0; }
 
     /// Compute PID.
-    double compute(double error);
+    float compute(float error);
 
     /// Initialize the object from a Protobuf message.
     void pb_read(
@@ -97,12 +97,12 @@ public:
     };
 
 private:
-    double kp_;                     ///< proportional gain
-    double ki_;                     ///< integral gain
-    double kd_;                     ///< derivative gain
-    double integral_term_;          ///< error sum
-    double integral_term_limit_;    ///< error sum maximum limit
-    double previous_error_;         ///< previous sum
+    float kp_;                     ///< proportional gain
+    float ki_;                     ///< integral gain
+    float kd_;                     ///< derivative gain
+    float integral_term_;          ///< error sum
+    float integral_term_limit_;    ///< error sum maximum limit
+    float previous_error_;         ///< previous sum
 };
 
 } // namespace pid

--- a/lib/trigonometry/include/trigonometry.h
+++ b/lib/trigonometry/include/trigonometry.h
@@ -23,7 +23,7 @@ extern "C" {
 /// @param x
 /// @param y
 /// @return
-inline double periodicmod(double x, double y)
+inline float periodicmod(float x, float y)
 {
     return fmod(fmod(x, y) + y, y);  // ((x % y) + y) % y
 }
@@ -39,24 +39,24 @@ inline double periodicmod(double x, double y)
 /// @param x Value to map
 /// @param min min interval
 /// @param max max interval
-/// @return double the mapped value
-inline double inrange(double x, double min, double max)
+/// @return float the mapped value
+inline float inrange(float x, float min, float max)
 {
     return periodicmod(x - min, max - min) + min;
 }
 
 /// @brief limit angle in radians
 /// @param O The value to map between -pi and pi
-/// @return double the mapped value
-inline double limit_angle_rad(double O)
+/// @return float the mapped value
+inline float limit_angle_rad(float O)
 {
     return inrange(O, -etl::math::pi, etl::math::pi);
 }
 
 /// @brief limit angle in degrees
 /// @param O The value to map between -180 and 180
-/// @return double the mapped value
-inline double limit_angle_deg(double O)
+/// @return float the mapped value
+inline float limit_angle_deg(float O)
 {
     return inrange(O, -180, 180);
 }

--- a/lib/utils/include/utils.hpp
+++ b/lib/utils/include/utils.hpp
@@ -3,7 +3,7 @@
 typedef void (*func_cb_t)(void);
 
 /**
- * @brief Compare two floating-point numbers (double) with a specified tolerance.
+ * @brief Compare two floating-point numbers (float) with a specified tolerance.
  *
  * This function checks if the absolute difference between two doubles is less than a given tolerance (epsilon),
  * which helps to address the imprecision of floating-point calculations.
@@ -14,7 +14,7 @@ typedef void (*func_cb_t)(void);
  * @return true         If the absolute difference between a and b is less than epsilon.
  * @return false        Otherwise.
  */
-bool areDoublesEqual(double a, double b, double epsilon = 1e-3);
+bool areDoublesEqual(float a, float b, float epsilon = 1e-3);
 
 #define FALSE   (0)
 #define TRUE    (!FALSE)

--- a/lib/utils/utils.cpp
+++ b/lib/utils/utils.cpp
@@ -2,6 +2,6 @@
 
 #include <cmath>
 
-bool areDoublesEqual(double a, double b, double epsilon) {
+bool areDoublesEqual(float a, float b, float epsilon) {
     return std::fabs(a - b) < epsilon;
 }

--- a/motion_control/controllers/passthrough_pose_pid_controller/PassthroughPosePIDController.cpp
+++ b/motion_control/controllers/passthrough_pose_pid_controller/PassthroughPosePIDController.cpp
@@ -19,15 +19,15 @@ void PassthroughPosePIDController::execute() {
     COGIP_DEBUG_COUT("Execute PassthroughPosePIDController");
 
     // Read position error
-    double position_error = this->inputs_[0];
+    float position_error = this->inputs_[0];
 
-    double position_error_sign = 1;
+    float position_error_sign = 1;
 
     if (parameters_->signed_target_speed() && (position_error != 0)) {
         position_error_sign = position_error / fabs(position_error);
     }
 
-    double speed_order = parameters_->target_speed();
+    float speed_order = parameters_->target_speed();
     if (position_error != 0) {
         // Compute output values
         speed_order *= position_error_sign;

--- a/motion_control/controllers/passthrough_pose_pid_controller/include/passthrough_pose_pid_controller/PassthroughPosePIDControllerParameters.hpp
+++ b/motion_control/controllers/passthrough_pose_pid_controller/include/passthrough_pose_pid_controller/PassthroughPosePIDControllerParameters.hpp
@@ -24,16 +24,16 @@ class PassthroughPosePIDControllerParameters {
 public:
     /// Constructor
     PassthroughPosePIDControllerParameters(
-        double target_speed = 0.0,          ///< [in] PID parameters
+        float target_speed = 0.0,          ///< [in] PID parameters
         bool signed_target_speed = true     ///< [in] target speed signed flag
     ) : target_speed_(target_speed), signed_target_speed_(signed_target_speed) {};
 
     /// Get target speed parameter
     /// return     target speed
-    double target_speed() const { return target_speed_; };
+    float target_speed() const { return target_speed_; };
 
     void set_target_speed(
-        double target_speed
+        float target_speed
         ) { target_speed_ = target_speed; }
 
     /// Get force target speed flag
@@ -46,7 +46,7 @@ public:
 
 private:
     /// Target speed
-    double target_speed_;
+    float target_speed_;
 
     /// Force target speed flag. If set, speed_order is forced to target_speed
     bool signed_target_speed_;

--- a/motion_control/controllers/pose_pid_controller/PosePIDController.cpp
+++ b/motion_control/controllers/pose_pid_controller/PosePIDController.cpp
@@ -19,10 +19,10 @@ void PosePIDController::execute() {
     COGIP_DEBUG_COUT("Execute PosePIDController");
 
     // Read position error.
-    double position_error = this->inputs_[0];
+    float position_error = this->inputs_[0];
 
     // Compute output values.
-    double speed_order = parameters_->pid()->compute(position_error);
+    float speed_order = parameters_->pid()->compute(position_error);
 
     // Store speed order
     this->outputs_[0] = speed_order;

--- a/motion_control/controllers/speed_pid_controller/SpeedPIDController.cpp
+++ b/motion_control/controllers/speed_pid_controller/SpeedPIDController.cpp
@@ -20,10 +20,10 @@ void SpeedPIDController::execute() {
     COGIP_DEBUG_COUT("Execute SpeedPIDController");
 
     // Speed error
-    double speed_error = this->inputs_[0];
+    float speed_error = this->inputs_[0];
 
     // Compute output values.
-    double speed_command = parameters_->pid()->compute(speed_error);
+    float speed_command = parameters_->pid()->compute(speed_error);
 
     // Store output values.
     this->outputs_[0] = speed_command;

--- a/motion_control/drive_controller/include/drive_controller/DifferentialDriveController.hpp
+++ b/motion_control/drive_controller/include/drive_controller/DifferentialDriveController.hpp
@@ -39,17 +39,17 @@ public:
     int set_polar_velocity(cogip_defs::Polar &command) override
     {
         // Compute wheel speed in mm/period from polar speed
-        const double left_wheel_speed_mm_per_period = command.distance() - (DEG2RAD(command.angle()) * parameters_.track_width_mm() / 2);
-        const double right_wheel_speed_mm_per_period = command.distance() + (DEG2RAD(command.angle()) * parameters_.track_width_mm() / 2);
+        const float left_wheel_speed_mm_per_period = command.distance() - (DEG2RAD(command.angle()) * parameters_.track_width_mm() / 2);
+        const float right_wheel_speed_mm_per_period = command.distance() + (DEG2RAD(command.angle()) * parameters_.track_width_mm() / 2);
 
         // Compute wheel speed in mm/s and rad/s from mm/period and rad/period speeds
-        const double left_wheel_speed_mm_per_s = left_wheel_speed_mm_per_period * 1000 / parameters_.loop_period_ms();
-        const double right_wheel_speed_mm_per_s = right_wheel_speed_mm_per_period * 1000 / parameters_.loop_period_ms();
+        const float left_wheel_speed_mm_per_s = left_wheel_speed_mm_per_period * 1000 / parameters_.loop_period_ms();
+        const float right_wheel_speed_mm_per_s = right_wheel_speed_mm_per_period * 1000 / parameters_.loop_period_ms();
 
         // Compute motor speed in percent using the motor constant.
         // The motor constant allow convert a speed in mm/s into a speed ratio (% of nominal motor voltage).
-        double left_motor_speed_percent = (left_wheel_speed_mm_per_s / (etl::math::pi * parameters_.left_wheel_diameter_mm())) * parameters_.left_motor_constant();
-        double right_motor_speed_percent = (right_wheel_speed_mm_per_s / (etl::math::pi * parameters_.right_wheel_diameter_mm())) * parameters_.right_motor_constant();
+        float left_motor_speed_percent = (left_wheel_speed_mm_per_s / (etl::math::pi * parameters_.left_wheel_diameter_mm())) * parameters_.left_motor_constant();
+        float right_motor_speed_percent = (right_wheel_speed_mm_per_s / (etl::math::pi * parameters_.right_wheel_diameter_mm())) * parameters_.right_motor_constant();
 
         left_motor_speed_percent =
             (left_motor_speed_percent < 0 ? -parameters_.min_speed_percentage()

--- a/motion_control/drive_controller/include/drive_controller/DifferentialDriveControllerParameters.hpp
+++ b/motion_control/drive_controller/include/drive_controller/DifferentialDriveControllerParameters.hpp
@@ -23,14 +23,14 @@ public:
     /// @param min_speed_percentage min speed ratio to send to motors (%) in range [0;100]
     /// @param max_speed_percentage max speed ratio to send to motors (%) in range [0;100]
     /// @param loop_period regulation loop period (ms)
-    DifferentialDriveControllerParameters(double left_wheel_diameter,
-                                          double right_wheel_diameter,
-                                          double track_width,
-                                          double left_motor_constant,
-                                          double right_motor_constant,
-                                          double min_speed_percentage,
-                                          double max_speed_percentage,
-                                          double loop_period)
+    DifferentialDriveControllerParameters(float left_wheel_diameter,
+                                          float right_wheel_diameter,
+                                          float track_width,
+                                          float left_motor_constant,
+                                          float right_motor_constant,
+                                          float min_speed_percentage,
+                                          float max_speed_percentage,
+                                          float loop_period)
                                           : left_wheel_diameter_(left_wheel_diameter),
                                             right_wheel_diameter_(right_wheel_diameter),
                                             track_width_(track_width),
@@ -42,19 +42,19 @@ public:
 
     /// @brief Set the left motor wheel diameter dimension
     /// @param wheel_diameter Wheel diameter value (mm)
-    void set_left_wheel_diameter(double wheel_diameter) { left_wheel_diameter_ = wheel_diameter; }
+    void set_left_wheel_diameter(float wheel_diameter) { left_wheel_diameter_ = wheel_diameter; }
 
     /// @brief Return left motor wheel diameter value in mm.
-    /// @return double Wheel diameter value (mm)
-    double left_wheel_diameter_mm() const { return left_wheel_diameter_; }
+    /// @return float Wheel diameter value (mm)
+    float left_wheel_diameter_mm() const { return left_wheel_diameter_; }
 
     /// @brief Set the right wheel motor diameter dimension
     /// @param wheel_diameter Wheel diameter value (mm)
-    void set_right_wheel_diameter(double wheel_diameter) { right_wheel_diameter_ = wheel_diameter; }
+    void set_right_wheel_diameter(float wheel_diameter) { right_wheel_diameter_ = wheel_diameter; }
 
     /// @brief Return right motor wheel diameter value in mm.
-    /// @return double Wheel diameter value (mm)
-    double right_wheel_diameter_mm() const { return right_wheel_diameter_; }
+    /// @return float Wheel diameter value (mm)
+    float right_wheel_diameter_mm() const { return right_wheel_diameter_; }
 
     /// @brief Set the left motor constant value.
     ///        This value needs to be defined by using the motors characteristics from the datasheet.
@@ -64,11 +64,11 @@ public:
     ///
     /// @note motor_constant = ((60 * Reduction Ratio / velocity Constant (RPM/V)) / Motor Voltage (V)) * 100
     /// @param motor_constant motor constant (no unit)
-    void set_left_motor_constant(double motor_constant) { left_motor_constant_ = motor_constant; }
+    void set_left_motor_constant(float motor_constant) { left_motor_constant_ = motor_constant; }
 
     /// @brief Return left motor constant value
-    /// @return double motor constant (no unit)
-    double left_motor_constant() const { return left_motor_constant_; }
+    /// @return float motor constant (no unit)
+    float left_motor_constant() const { return left_motor_constant_; }
 
     /// @brief Set the right wheel motor constant value.
     ///        This value needs to be defined by using the motors characteristics from the datasheet.
@@ -78,53 +78,53 @@ public:
     ///
     /// @note motor_constant = ((60 * Reduction Ratio / velocity Constant (RPM/V)) / Motor Voltage (V)) * 100
     /// @param motor_constant motor constant (no unit)
-    void set_right_motor_constant(double motor_constant) { right_motor_constant_ = motor_constant; }
+    void set_right_motor_constant(float motor_constant) { right_motor_constant_ = motor_constant; }
 
     /// @brief Return right motor constant value
-    /// @return double Wheel motor constant (no unit)
-    double right_motor_constant() const { return right_motor_constant_; }
+    /// @return float Wheel motor constant (no unit)
+    float right_motor_constant() const { return right_motor_constant_; }
 
     /// @brief Set the axle track dimension
     /// @param track_width Track width value (mm)
-    void set_track_width(double track_width) { track_width_ = track_width; }
+    void set_track_width(float track_width) { track_width_ = track_width; }
 
     /// @brief Get the axle track value
-    /// @return double Track width value (mm)
-    double track_width_mm() const { return track_width_; }
+    /// @return float Track width value (mm)
+    float track_width_mm() const { return track_width_; }
 
     /// @brief Set the min speed ratio in percent
     /// @param min speed ratio (%)
-    void set_min_speed_percentage(double min) { min_speed_percentage_ = min; }
+    void set_min_speed_percentage(float min) { min_speed_percentage_ = min; }
 
     /// @brief get the min speed ratio in percent
-    /// @return double speed ratio (%)
-    double min_speed_percentage() { return min_speed_percentage_; }
+    /// @return float speed ratio (%)
+    float min_speed_percentage() { return min_speed_percentage_; }
 
     /// @brief Set the max speed ratio in percent
     /// @param max speed ratio (%)
-    void set_max_speed_percentage(double max) { max_speed_percentage_ = max; }
+    void set_max_speed_percentage(float max) { max_speed_percentage_ = max; }
 
     /// @brief get the max speed ratio in percent
-    /// @return double speed ratio (%)
-    double max_speed_percentage() const { return max_speed_percentage_; }
+    /// @return float speed ratio (%)
+    float max_speed_percentage() const { return max_speed_percentage_; }
 
     /// @brief Set the loop period in milliseconds
     /// @param period loop period (ms)
-    void set_loop_period(double period) { loop_period_ = period; }
+    void set_loop_period(float period) { loop_period_ = period; }
 
     /// @brief Get the axle track value
-    /// @return double Track width value (mm)
-    double loop_period_ms() const { return loop_period_; }
+    /// @return float Track width value (mm)
+    float loop_period_ms() const { return loop_period_; }
 
 private:
-    double left_wheel_diameter_;
-    double right_wheel_diameter_;
-    double track_width_;
-    double left_motor_constant_;
-    double right_motor_constant_;
-    double min_speed_percentage_;
-    double max_speed_percentage_;
-    double loop_period_;
+    float left_wheel_diameter_;
+    float right_wheel_diameter_;
+    float track_width_;
+    float left_motor_constant_;
+    float right_motor_constant_;
+    float min_speed_percentage_;
+    float max_speed_percentage_;
+    float loop_period_;
 };
 
 } // namespace odometer

--- a/motion_control/engines/motor_engine/include/motor_engine/MotorEngine.hpp
+++ b/motion_control/engines/motor_engine/include/motor_engine/MotorEngine.hpp
@@ -21,7 +21,7 @@ namespace cogip {
 namespace motion_control {
 
 /// Get current speed and pose from motor
-using motor_get_speed_and_pose_cb_t = etl::delegate<void(double&, double&)>;
+using motor_get_speed_and_pose_cb_t = etl::delegate<void(float&, float&)>;
 
 /// Process motion control commands
 using motor_process_commands_cb_t = etl::delegate<void(const int, BaseControllerEngine&)>;
@@ -41,33 +41,33 @@ public:
 
     /// Get current speed
     /// return     current speed
-    const double& current_speed() const { return current_speed_; };
+    const float& current_speed() const { return current_speed_; };
 
     /// Get target speed
     /// return     target speed
-    const double& target_speed() const { return target_speed_; };
+    const float& target_speed() const { return target_speed_; };
 
     /// Get current pose
     /// return     current pose
-    const double& current_pose() const { return current_pose_; };
+    const float& current_pose() const { return current_pose_; };
 
     /// Get target pose
     /// return     target pose
-    const double& target_pose() const { return target_pose_; };
+    const float& target_pose() const { return target_pose_; };
 
     /// Set target speed
     void set_target_speed(
-        const double target_speed   ///< [in]   new target speed
+        const float target_speed   ///< [in]   new target speed
         ) { target_speed_ = target_speed; };
 
     /// Set current pose
     void set_current_pose(
-        const double current_pose    ///< [in]   new current pose
+        const float current_pose    ///< [in]   new current pose
         ) { current_pose_ = current_pose; };
 
     /// Set target pose
     void set_target_pose(
-        const double target_pose     ///< [in]   new target pose
+        const float target_pose     ///< [in]   new target pose
         ) { target_pose_ = target_pose; };
 
 private:
@@ -78,16 +78,16 @@ private:
     void process_outputs();
 
     /// Robot polar current speed
-    double current_speed_;
+    float current_speed_;
 
     /// Robot polar target speed
-    double target_speed_;
+    float target_speed_;
 
     /// Robot current pose
-    double current_pose_;
+    float current_pose_;
 
     /// Robot target pose
-    double target_pose_;
+    float target_pose_;
 
     /// Motor callback to get target and current poses from motors
     motor_get_speed_and_pose_cb_t motor_get_speed_and_pose_cb_;

--- a/motion_control/filters/motor_pose_filter/MotorPoseFilter.cpp
+++ b/motion_control/filters/motor_pose_filter/MotorPoseFilter.cpp
@@ -21,16 +21,16 @@ void MotorPoseFilter::execute() {
     size_t input_index = 0;
 
     // Current pose
-    double current_pose = this->inputs_[input_index++];
+    float current_pose = this->inputs_[input_index++];
 
     // Target pose
-    double target_pose = this->inputs_[input_index++];
+    float target_pose = this->inputs_[input_index++];
 
     // Current speed
-    double current_speed = this->inputs_[input_index++];
+    float current_speed = this->inputs_[input_index++];
 
     // Target speed
-    double target_speed = this->inputs_[input_index++];
+    float target_speed = this->inputs_[input_index++];
 
     // Position reached flag
     target_pose_status_t pose_reached = (target_pose_status_t)this->inputs_[input_index++];
@@ -41,7 +41,7 @@ void MotorPoseFilter::execute() {
     }
 
     // compute position error
-    double pos_err = target_pose - current_pose;
+    float pos_err = target_pose - current_pose;
 
     // Do not disable speed limitation
     bool no_speed_limit = false;
@@ -62,10 +62,10 @@ void MotorPoseFilter::execute() {
     // Target speed
     outputs_[2] = fabs(target_speed);
     // Should speed be filtered ?
-    outputs_[3] = (double)no_speed_limit;
+    outputs_[3] = (float)no_speed_limit;
 
     // Pose reached
-    outputs_[4] = (double)pose_reached;
+    outputs_[4] = (float)pose_reached;
 };
 
 } // namespace motion_control

--- a/motion_control/filters/motor_pose_filter/include/motor_pose_filter/MotorPoseFilterParameters.hpp
+++ b/motion_control/filters/motor_pose_filter/include/motor_pose_filter/MotorPoseFilterParameters.hpp
@@ -21,26 +21,26 @@ class MotorPoseFilterParameters {
 public:
     /// Constructor
     MotorPoseFilterParameters(
-        double threshold = 0.0,   ///< [in]  see linear_threshold_
-        double deceleration = 0.0    ///< [in]  see linear_deceleration_threshold_
+        float threshold = 0.0,   ///< [in]  see linear_threshold_
+        float deceleration = 0.0    ///< [in]  see linear_deceleration_threshold_
     ) :
     threshold_(threshold),
     deceleration_(deceleration) {};
 
     /// Get threshold
     /// return threshold
-    double threshold() const { return threshold_; };
+    float threshold() const { return threshold_; };
 
     /// Get deceleration
     /// return deceleration
-    double deceleration() const { return deceleration_; };
+    float deceleration() const { return deceleration_; };
 
 private:
     /// the motor has reach the pose when the error is lower than this threshold
-    double threshold_;
+    float threshold_;
 
     /// deceleration
-    double deceleration_;
+    float deceleration_;
 };
 
 } // namespace motion_control

--- a/motion_control/filters/pose_straight_filter/PoseStraightFilter.cpp
+++ b/motion_control/filters/pose_straight_filter/PoseStraightFilter.cpp
@@ -23,9 +23,9 @@ void PoseStraightFilter::execute() {
     size_t input_index = 0;
 
     // Current pose
-    double current_pose_x = inputs_[input_index++];
-    double current_pose_y = inputs_[input_index++];
-    double current_pose_O = inputs_[input_index++];
+    float current_pose_x = inputs_[input_index++];
+    float current_pose_y = inputs_[input_index++];
+    float current_pose_O = inputs_[input_index++];
     cogip_defs::Pose current_pose(
         current_pose_x,
         current_pose_y,
@@ -33,9 +33,9 @@ void PoseStraightFilter::execute() {
     );
 
     // Target pose
-    double target_pose_x = this->inputs_[input_index++];
-    double target_pose_y = this->inputs_[input_index++];
-    double target_pose_O = this->inputs_[input_index++];
+    float target_pose_x = this->inputs_[input_index++];
+    float target_pose_y = this->inputs_[input_index++];
+    float target_pose_O = this->inputs_[input_index++];
     cogip_defs::Pose target_pose(
         target_pose_x,
         target_pose_y,
@@ -43,16 +43,16 @@ void PoseStraightFilter::execute() {
     );
 
     // Current speed
-    double current_linear_speed = this->inputs_[input_index++];
-    double current_angular_speed = this->inputs_[input_index++];
+    float current_linear_speed = this->inputs_[input_index++];
+    float current_angular_speed = this->inputs_[input_index++];
     cogip_defs::Polar current_speed(
         current_linear_speed,
         current_angular_speed
     );
 
     // Target speed
-    double target_linear_speed = this->inputs_[input_index++];
-    double target_angular_speed = this->inputs_[input_index++];
+    float target_linear_speed = this->inputs_[input_index++];
+    float target_angular_speed = this->inputs_[input_index++];
     cogip_defs::Polar target_speed(
         target_linear_speed,
         target_angular_speed
@@ -175,7 +175,7 @@ void PoseStraightFilter::execute() {
     // Linear target speed
     outputs_[2] = fabs(target_speed.distance());
     // Should linear speed be filtered?
-    outputs_[3] = (double)no_linear_speed_limit;
+    outputs_[3] = (float)no_linear_speed_limit;
 
     // Angular pose error
     outputs_[4] = pos_err.angle();
@@ -184,10 +184,10 @@ void PoseStraightFilter::execute() {
     // Angular target speed
     outputs_[6] = fabs(target_speed.angle());
     // Should angular speed be filtered?
-    outputs_[7] = (double)no_angular_speed_limit;
+    outputs_[7] = (float)no_angular_speed_limit;
 
     // Pose reached
-    outputs_[8] = (double)pose_reached;
+    outputs_[8] = (float)pose_reached;
 };
 
 } // namespace motion_control

--- a/motion_control/filters/pose_straight_filter/include/pose_straight_filter/PoseStraightFilterParameters.hpp
+++ b/motion_control/filters/pose_straight_filter/include/pose_straight_filter/PoseStraightFilterParameters.hpp
@@ -21,11 +21,11 @@ class PoseStraightFilterParameters {
 public:
     /// Constructor
     PoseStraightFilterParameters(
-        double angular_threshold = 0.0,  ///< [in]  see angular_threshold_
-        double linear_threshold = 0.0,   ///< [in]  see linear_threshold_
-        double angular_intermediate_threshold = 0.0,  ///< [in]  see angular_threshold_
-        double angular_deceleration = 0.0,  ///< [in]  see angular_deceleration_threshold_
-        double linear_deceleration = 0.0,   ///< [in]  see linear_deceleration_threshold_
+        float angular_threshold = 0.0,  ///< [in]  see angular_threshold_
+        float linear_threshold = 0.0,   ///< [in]  see linear_threshold_
+        float angular_intermediate_threshold = 0.0,  ///< [in]  see angular_threshold_
+        float angular_deceleration = 0.0,  ///< [in]  see angular_deceleration_threshold_
+        float linear_deceleration = 0.0,   ///< [in]  see linear_deceleration_threshold_
         bool bypass_final_orientation = false  ///< [in] bypass final orientation
     ) :
     angular_threshold_(angular_threshold),
@@ -37,47 +37,47 @@ public:
 
     /// Get angular threshold
     /// return angular threshold
-    double angular_threshold() const { return angular_threshold_; };
+    float angular_threshold() const { return angular_threshold_; };
 
     /// Set angular threshold
     void set_angular_threshold(
-        double angular_threshold                            ///< [in]   angular threshold
+        float angular_threshold                            ///< [in]   angular threshold
         ) { angular_threshold_ = angular_threshold; };
 
     /// Get linear threshold
     /// return Linear threshold
-    double linear_threshold() const { return linear_threshold_; };
+    float linear_threshold() const { return linear_threshold_; };
 
     /// Get angular intermediate threshold
     /// return angular intermediate threshold
-    double angular_intermediate_threshold() const { return angular_intermediate_threshold_; };
+    float angular_intermediate_threshold() const { return angular_intermediate_threshold_; };
 
     /// Set angular threshold
     void set_intermediate_angular_threshold(
-        double angular_intermediate_threshold                            ///< [in]   intermediate angular threshold
+        float angular_intermediate_threshold                            ///< [in]   intermediate angular threshold
         ) { angular_intermediate_threshold_ = angular_intermediate_threshold; };
 
     /// Get angular deceleration
     /// return Angular deceleration
-    double angular_deceleration() const { return angular_deceleration_; };
+    float angular_deceleration() const { return angular_deceleration_; };
 
     /// Get linear deceleration
     /// return Linear deceleration
-    double linear_deceleration() const { return linear_deceleration_; };
+    float linear_deceleration() const { return linear_deceleration_; };
 
     /// Set linear threshold
     void set_linear_threshold(
-        double linear_threshold                             ///< [in]   linear threshold
+        float linear_threshold                             ///< [in]   linear threshold
         ) { linear_threshold_ = linear_threshold; };
 
     /// Set angular deceleration
     void set_angular_deceleration(
-        double angular_deceleration                         ///< [in]   angular deceleration
+        float angular_deceleration                         ///< [in]   angular deceleration
         ) { angular_deceleration_ = angular_deceleration; };
 
     /// Set linear deceleration
     void set_linear_deceleration(
-        double linear_deceleration                          ///< [in]   linear deceleration
+        float linear_deceleration                          ///< [in]   linear deceleration
         ) { linear_deceleration_ = linear_deceleration; };
 
     /// Return final orientation bypass
@@ -91,19 +91,19 @@ public:
 
 private:
     /// the robot turns on itself until the angle error is lower than this threshold
-    double angular_threshold_;
+    float angular_threshold_;
 
     /// the robot has reach the point when the linear error is lower than this threshold
-    double linear_threshold_;
+    float linear_threshold_;
 
     /// the robot turns on itself until the angle error is lower than this threshold to reach its final destination
-    double angular_intermediate_threshold_;
+    float angular_intermediate_threshold_;
 
     /// angular deceleration
-    double angular_deceleration_;
+    float angular_deceleration_;
 
     /// linear deceleration
-    double linear_deceleration_;
+    float linear_deceleration_;
 
     /// bypass final orientation
     bool bypass_final_orientation_;

--- a/motion_control/filters/speed_filter/SpeedFilter.cpp
+++ b/motion_control/filters/speed_filter/SpeedFilter.cpp
@@ -17,19 +17,19 @@ namespace cogip {
 namespace motion_control {
 
 void SpeedFilter::limit_speed_order(
-    double *speed_order,
-    double target_speed,
-    double current_speed,
-    double min_speed,
-    double max_speed,
-    double max_acc
+    float *speed_order,
+    float target_speed,
+    float current_speed,
+    float min_speed,
+    float max_speed,
+    float max_acc
     )
 {
     // Limit target speed
     target_speed = std::min(target_speed, max_speed);
 
     // Limit speed command (maximum acceleration)
-    double a = *speed_order - current_speed;
+    float a = *speed_order - current_speed;
 
     if (a > max_acc) {
         a =  max_acc;
@@ -57,11 +57,11 @@ void SpeedFilter::execute() {
     COGIP_DEBUG_COUT("Execute SpeedFilter");
 
     // Speed order
-    double speed_order = this->inputs_[0];
+    float speed_order = this->inputs_[0];
     // Current speed
-    double current_speed = this->inputs_[1];
+    float current_speed = this->inputs_[1];
     // Target speed
-    double target_speed = this->inputs_[2];
+    float target_speed = this->inputs_[2];
     // Do not filter speed order ?
     bool no_speed_filter = this->inputs_[3];
     // Pose reached

--- a/motion_control/filters/speed_filter/include/speed_filter/SpeedFilter.hpp
+++ b/motion_control/filters/speed_filter/include/speed_filter/SpeedFilter.hpp
@@ -36,7 +36,7 @@ public:
 
     /// Get previous speed order
     /// return previous speed order
-    double previous_speed_order() const { return previous_speed_order_; };
+    float previous_speed_order() const { return previous_speed_order_; };
 
     /// Reset previous speed order
     void reset_previous_speed_order() { previous_speed_order_ = 0; };
@@ -46,18 +46,18 @@ public:
 
 protected:
     /// Previous cycle speed_order
-    double previous_speed_order_;
+    float previous_speed_order_;
 
     /// Anti blocking, number of blocked cycle
     uint32_t anti_blocking_blocked_cycles_nb_;
 
     void limit_speed_order(
-        double *speed_order,
-        double target_speed,
-        double current_speed,
-        double min_speed,
-        double max_speed,
-        double max_acc
+        float *speed_order,
+        float target_speed,
+        float current_speed,
+        float min_speed,
+        float max_speed,
+        float max_acc
     );
 
 };

--- a/motion_control/filters/speed_filter/include/speed_filter/SpeedFilterParameters.hpp
+++ b/motion_control/filters/speed_filter/include/speed_filter/SpeedFilterParameters.hpp
@@ -20,16 +20,16 @@ class SpeedFilterParameters {
 public:
     /// Constructor
     SpeedFilterParameters(
-        double min_speed = 0.0,         ///< [in]  see max_speed_
-        double max_speed = 0.0,         ///< [in]  see max_speed_
-        double max_acceleration = 0.0,  ///< [in]  see max_acceleration_
+        float min_speed = 0.0,         ///< [in]  see max_speed_
+        float max_speed = 0.0,         ///< [in]  see max_speed_
+        float max_acceleration = 0.0,  ///< [in]  see max_acceleration_
         bool anti_blocking = false,
                                         ///< [in]   anti-blocking flag
-        double anti_blocking_speed_threshold = 0,
+        float anti_blocking_speed_threshold = 0,
                                         ///< [in]   new anti blocking speed threshold
-        double anti_blocking_error_threshold = 0,
+        float anti_blocking_error_threshold = 0,
                                         ///< [in]   new anti blocking error threshold
-        double anti_blocking_blocked_cycles_nb_threshold = 0
+        float anti_blocking_blocked_cycles_nb_threshold = 0
                                         ///< [in]   new anti blocking blocked cycles threshold
     ) :  min_speed_(min_speed), max_speed_(max_speed), max_acceleration_(max_acceleration),
          anti_blocking_(anti_blocking),
@@ -39,29 +39,29 @@ public:
 
     /// Get minimum speed
     /// return minimum speed
-    double min_speed() const { return min_speed_; };
+    float min_speed() const { return min_speed_; };
 
     /// Get maximum speed
     /// return maximum speed
-    double max_speed() const { return max_speed_; };
+    float max_speed() const { return max_speed_; };
 
     /// Get maximum acceleration
     /// return maximum acceleration
-    double max_acceleration() const { return max_acceleration_; };
+    float max_acceleration() const { return max_acceleration_; };
 
     /// Set minimum speed
     void set_min_speed(
-        double min_speed                ///< [in]   minimum speed
+        float min_speed                ///< [in]   minimum speed
         ) { min_speed_ = min_speed; };
 
     /// Set maximum speed
     void set_max_speed(
-        double max_speed                ///< [in]   maximum speed
+        float max_speed                ///< [in]   maximum speed
         ) { max_speed_ = max_speed; };
 
     /// Set maximum acceleration
     void set_max_acceleration(
-        double max_acceleration         ///< [in]   maximum acceleration
+        float max_acceleration         ///< [in]   maximum acceleration
         ) { max_acceleration_ = max_acceleration; };
 
     /// Get anti blocking activation flag
@@ -75,50 +75,50 @@ public:
 
     /// Get anti blocking speed threshold
     /// return anti blocking speed threshold
-    double anti_blocking_speed_threshold() const { return anti_blocking_speed_threshold_; };
+    float anti_blocking_speed_threshold() const { return anti_blocking_speed_threshold_; };
 
     /// Set anti blocking speed threshold
     void set_anti_blocking_speed_threshold(
-        double anti_blocking_speed_threshold        ///< [in]   new anti blocking speed threshold
+        float anti_blocking_speed_threshold        ///< [in]   new anti blocking speed threshold
         ) { anti_blocking_speed_threshold_ = anti_blocking_speed_threshold; };
 
     /// Get anti blocking error threshold
     /// return anti blocking error threshold
-    double anti_blocking_error_threshold() const { return anti_blocking_error_threshold_; };
+    float anti_blocking_error_threshold() const { return anti_blocking_error_threshold_; };
 
     /// Set anti blocking error threshold
     void set_anti_blocking_error_threshold(
-        double anti_blocking_error_threshold        ///< [in]   new anti blocking error threshold
+        float anti_blocking_error_threshold        ///< [in]   new anti blocking error threshold
         ) { anti_blocking_error_threshold_ = anti_blocking_error_threshold; };
 
     /// Get anti blocking blocked cycles number threshold
     /// return anti blocking blocked cycles number threshold
-    double anti_blocking_blocked_cycles_nb_threshold() const { return anti_blocking_blocked_cycles_nb_threshold_; };
+    float anti_blocking_blocked_cycles_nb_threshold() const { return anti_blocking_blocked_cycles_nb_threshold_; };
 
     /// Set anti blocking blocked cycles number threshold
     void set_anti_blocking_blocked_cycles_nb_threshold(
-        double anti_blocking_blocked_cycles_nb_threshold        ///< [in]   new anti blocking blocked cycles number threshold
+        float anti_blocking_blocked_cycles_nb_threshold        ///< [in]   new anti blocking blocked cycles number threshold
         ) { anti_blocking_blocked_cycles_nb_threshold_ = anti_blocking_blocked_cycles_nb_threshold; };
 
 
 private:
     /// maximum speed the robot can reach
-    double min_speed_;
+    float min_speed_;
 
     /// maximum speed the robot can reach
-    double max_speed_;
+    float max_speed_;
 
     /// maximum robot acceleration allowed
-    double max_acceleration_;
+    float max_acceleration_;
 
     /// Anti blocking on ?
     bool anti_blocking_;
 
     /// anti blocking speed threshold
-    double anti_blocking_speed_threshold_;
+    float anti_blocking_speed_threshold_;
 
     /// anti blocking error threshold
-    double anti_blocking_error_threshold_;
+    float anti_blocking_error_threshold_;
 
     /// anti blocking blocked cycles number threshold
     uint32_t anti_blocking_blocked_cycles_nb_threshold_;

--- a/motion_control/metas/polar_parallel_meta_controller/include/polar_parallel_meta_controller/PolarParallelMetaController.hpp
+++ b/motion_control/metas/polar_parallel_meta_controller/include/polar_parallel_meta_controller/PolarParallelMetaController.hpp
@@ -73,9 +73,9 @@ protected:
         // Angular command
         outputs_[1] = angular_ctrl->output(0);
         // Pose reached has been set by previous filter except if blocked
-        if ((linear_ctrl->output(1) == (double)target_pose_status_t::blocked)
-            || (angular_ctrl->output(1) == (double)target_pose_status_t::blocked)) {
-            outputs_[2] = (double)target_pose_status_t::blocked;
+        if ((linear_ctrl->output(1) == (float)target_pose_status_t::blocked)
+            || (angular_ctrl->output(1) == (float)target_pose_status_t::blocked)) {
+            outputs_[2] = (float)target_pose_status_t::blocked;
         }
         else {
             outputs_[2] = inputs_[8];

--- a/motion_control/motion_control_common/include/motion_control_common/BaseController.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/BaseController.hpp
@@ -43,26 +43,26 @@ public:
 
     /// Get input at given index
     /// return input
-    virtual double input (
+    virtual float input (
         size_t index    ///< [in]  index
         ) const = 0;
 
     /// Set input at given index
     virtual void set_input(
         size_t index,   ///< [in]  index
-        double value    ///< [in]  value
+        float value    ///< [in]  value
         ) = 0;
 
     /// Get output at given index
     /// return output
-    virtual double output (
+    virtual float output (
         size_t index    ///< [in]  index
         ) const = 0;
 
     /// Set output at given index
     virtual void set_output(
         size_t index,   ///< [in]  index
-        double value    ///< [in]  value
+        float value    ///< [in]  value
         ) = 0;
 
     /// Get numer of inputs

--- a/motion_control/motion_control_common/include/motion_control_common/Controller.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/Controller.hpp
@@ -43,13 +43,13 @@ public:
     ) : BaseController(), parameters_(parameters) {};
 
     /// Get input at given index
-    /// return         input at given index, max double value if error
-    double input(
+    /// return         input at given index, max float value if error
+    float input(
         size_t index    ///< [in]  input index
         ) const override {
         if (index >= INPUT_SIZE) {
             COGIP_DEBUG_COUT("Error: not enough values.");
-            return std::numeric_limits<double>::max();
+            return std::numeric_limits<float>::max();
         }
         return this->inputs_[index];
     };
@@ -57,7 +57,7 @@ public:
     /// Set input at given index
     void set_input(
         size_t index,   ///< [in]  input index
-        double value    ///< [in]  value to set at given index
+        float value    ///< [in]  value to set at given index
         ) override {
         if (index >= INPUT_SIZE) {
             COGIP_DEBUG_COUT("Error: not enough input values.");
@@ -67,13 +67,13 @@ public:
     };
 
     /// Get output at given index
-    /// return         output at given index, max double value if error
-    double output(
+    /// return         output at given index, max float value if error
+    float output(
         size_t index    ///< [in]  output index
         ) const override {
         if (index >= OUTPUT_SIZE) {
             COGIP_DEBUG_COUT("Error: cannot get output at index " << index << ", not enough output values(" << OUTPUT_SIZE << ").");
-            return std::numeric_limits<double>::max();
+            return std::numeric_limits<float>::max();
         }
         return this->outputs_[index];
     };
@@ -81,7 +81,7 @@ public:
     /// Set output at given index
     void set_output(
         size_t index,   ///< [in]  output index
-        double value    ///< [in]  value to set at given index
+        float value    ///< [in]  value to set at given index
         ) override {
         if (index >= OUTPUT_SIZE) {
             COGIP_DEBUG_COUT("Error: cannot set output at index " << index << ", not enough output values(" << OUTPUT_SIZE << ").");
@@ -110,10 +110,10 @@ public:
 
 protected:
     /// Inputs vector
-    etl::vector<double, INPUT_SIZE> inputs_;
+    etl::vector<float, INPUT_SIZE> inputs_;
 
     /// outputs vector
-    etl::vector<double, OUTPUT_SIZE> outputs_;
+    etl::vector<float, OUTPUT_SIZE> outputs_;
 
     /// Controller parameters
     const ParamsT *parameters_;

--- a/platforms/pf-robot-motion-control/include/motion_control.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control.hpp
@@ -33,30 +33,30 @@ constexpr uint16_t motion_control_thread_period_ms = 20; ///< controller thread 
 /// @name Acceleration and speed profiles
 /// @{
 /// Maximum linear acceleration/deceleration (mm/<motion_control_thread_period_ms>²)
-constexpr double platform_max_acc_linear_mm_per_period2 = X_SEC2_TO_X_PERIOD2(max_acc_mm_per_s2, motion_control_thread_period_ms);
-constexpr double platform_max_dec_linear_mm_per_period2 = X_SEC2_TO_X_PERIOD2(max_dec_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_acc_linear_mm_per_period2 = X_SEC2_TO_X_PERIOD2(max_acc_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_linear_mm_per_period2 = X_SEC2_TO_X_PERIOD2(max_dec_mm_per_s2, motion_control_thread_period_ms);
 
 /// Minimum/Maximum linear speed (mm/<motion_control_thread_period_ms>)
-constexpr double platform_min_speed_linear_mm_per_period = X_SEC_TO_X_PERIOD(min_speed_mm_per_s, motion_control_thread_period_ms);
-constexpr double platform_max_speed_linear_mm_per_period = X_SEC_TO_X_PERIOD(max_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_min_speed_linear_mm_per_period = X_SEC_TO_X_PERIOD(min_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_linear_mm_per_period = X_SEC_TO_X_PERIOD(max_speed_mm_per_s, motion_control_thread_period_ms);
 
 /// Low angular speed (mm/<motion_control_thread_period_ms>)
-constexpr double platform_low_speed_linear_mm_per_period = (platform_max_speed_linear_mm_per_period / 4);
+constexpr float platform_low_speed_linear_mm_per_period = (platform_max_speed_linear_mm_per_period / 4);
 /// Normal angular speed (mm/<motion_control_thread_period_ms>)
-constexpr double platform_normal_speed_linear_mm_per_period = (platform_max_speed_linear_mm_per_period / 2);
+constexpr float platform_normal_speed_linear_mm_per_period = (platform_max_speed_linear_mm_per_period / 2);
 
 /// Maximum angular acceleration/deceleration (rad/<motion_control_thread_period_ms>²)
-constexpr double platform_max_acc_angular_deg_per_period2 = X_SEC2_TO_X_PERIOD2(max_acc_deg_per_s2, motion_control_thread_period_ms);
-constexpr double platform_max_dec_angular_deg_per_period2 = X_SEC2_TO_X_PERIOD2(max_dec_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_acc_angular_deg_per_period2 = X_SEC2_TO_X_PERIOD2(max_acc_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_angular_deg_per_period2 = X_SEC2_TO_X_PERIOD2(max_dec_deg_per_s2, motion_control_thread_period_ms);
 
 /// Minimum/Maximum angular speed (rad/<motion_control_thread_period_ms>)
-constexpr double platform_min_speed_angular_deg_per_period = X_SEC_TO_X_PERIOD(min_speed_deg_per_s, motion_control_thread_period_ms);
-constexpr double platform_max_speed_angular_deg_per_period = X_SEC_TO_X_PERIOD(max_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_min_speed_angular_deg_per_period = X_SEC_TO_X_PERIOD(min_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_angular_deg_per_period = X_SEC_TO_X_PERIOD(max_speed_deg_per_s, motion_control_thread_period_ms);
 
 /// Low angular speed (rad/<motion_control_thread_period_ms>)
-constexpr double platform_low_speed_angular_deg_per_period = (platform_max_speed_angular_deg_per_period / 4);
+constexpr float platform_low_speed_angular_deg_per_period = (platform_max_speed_angular_deg_per_period / 4);
 ///< Normal angular speed (deg/<motion_control_thread_period_ms>)
-constexpr double platform_normal_speed_angular_deg_per_period = (platform_max_speed_angular_deg_per_period / 2);
+constexpr float platform_normal_speed_angular_deg_per_period = (platform_max_speed_angular_deg_per_period / 2);
 /// @}
 
 /// Handle brake signal to stop the robot

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -520,10 +520,10 @@ void cogip_native_motor_driver_qdec_simulation(const motor_driver_t *motor_drive
     (void)motor_id;
     (void)pwm_duty_cycle;
 
-    static double wheels_perimeter = M_PI * left_encoder_wheels_diameter_mm;
-    static double pulse_per_mm = encoder_wheels_resolution_pulses / wheels_perimeter;
-    static double wheels_distance_pulse = encoder_wheels_distance_mm * pulse_per_mm;
-    static double pulse_per_degree = (wheels_distance_pulse * 2 * M_PI) / 360;
+    static float wheels_perimeter = M_PI * left_encoder_wheels_diameter_mm;
+    static float pulse_per_mm = encoder_wheels_resolution_pulses / wheels_perimeter;
+    static float wheels_distance_pulse = encoder_wheels_distance_mm * pulse_per_mm;
+    static float pulse_per_degree = (wheels_distance_pulse * 2 * M_PI) / 360;
 
     // On native architecture set speeds at their theorical value, no error.
     if (pf_motion_control_platform_engine.pose_reached() != cogip::motion_control::target_pose_status_t::reached) {

--- a/platforms/pf-robot-motors/Motor.cpp
+++ b/platforms/pf-robot-motors/Motor.cpp
@@ -21,7 +21,7 @@ Motor::Motor(
         motor_driver_t *motor_driver,
         uint8_t motor_id,
         gpio_t clear_overload_pin,
-        double target_speed,
+        float target_speed,
         cogip::motion_control::PosePIDControllerParameters *pose_controller_parameters,
         cogip::motion_control::SpeedPIDControllerParameters *speed_controller_parameters,
         cogip::motion_control::MotorPoseFilterParameters *motor_pose_filter_parameters,

--- a/platforms/pf-robot-motors/include/Motor.hpp
+++ b/platforms/pf-robot-motors/include/Motor.hpp
@@ -48,7 +48,7 @@ public:
         motor_driver_t *motor_driver = nullptr, ///< [in] motor driver
         uint8_t motor_id = 0,                   ///< [in] motor id for the given motor driver
         gpio_t clear_overload_pin = GPIO_UNDEF, ///< [in] clear motor overload flag
-        double target_speed = 0,                ///< [in] motor engine default target speed
+        float target_speed = 0,                ///< [in] motor engine default target speed
         cogip::motion_control::PosePIDControllerParameters *pose_controller_parameters = nullptr,
                                                 ///< [in] motor pose controller parameters
         cogip::motion_control::SpeedPIDControllerParameters *speed_controller_parameters = nullptr,
@@ -78,20 +78,20 @@ public:
 
     /// Get target speed
     /// return target speed
-    double target_speed() const { return motor_engine_.target_speed(); };
+    float target_speed() const { return motor_engine_.target_speed(); };
 
     /// Set target speed
     void set_target_speed(
-        double target_speed         ///< [in]   target speed (mm/period)
+        float target_speed         ///< [in]   target speed (mm/period)
         ) { motor_engine_.set_target_speed(target_speed); };
 
     /// Get current pose
     /// return current pose
-    double current_pose() const { return motor_engine_.current_pose(); };
+    float current_pose() const { return motor_engine_.current_pose(); };
 
     /// Set current pose
     void set_current_pose(
-        double current_pose     ///< [in]   current pose (mm)
+        float current_pose     ///< [in]   current pose (mm)
         ) { motor_engine_.set_current_pose(current_pose); };
 
 private:

--- a/platforms/pf-robot-motors/include/pf_positional_actuators.hpp
+++ b/platforms/pf-robot-motors/include/pf_positional_actuators.hpp
@@ -48,39 +48,39 @@ constexpr int pwm_minimal = 70;
 ///  - pulse_per_mm = wheels_encoder_resolution / wheels_perimeter
 ///
 /// @{
-constexpr double wheels_diameter_mm = 12.03;
-constexpr double wheels_encoder_resolution = 37.35 * 11 * 4;
-constexpr double wheels_perimeter_mm = M_PI * wheels_diameter_mm;
-constexpr double pulse_per_mm = wheels_encoder_resolution / wheels_perimeter_mm;///< WHEELS_ENCODER_RESOLUTION / WHEELS_PERIMETER
+constexpr float wheels_diameter_mm = 12.03;
+constexpr float wheels_encoder_resolution = 37.35 * 11 * 4;
+constexpr float wheels_perimeter_mm = M_PI * wheels_diameter_mm;
+constexpr float pulse_per_mm = wheels_encoder_resolution / wheels_perimeter_mm;///< WHEELS_ENCODER_RESOLUTION / WHEELS_PERIMETER
 /// @}
 
 ///< controller thread loop period
 constexpr uint16_t motor_lift_control_thread_period_ms = 20;
 
 /// Lift motors speed filter parameters
-constexpr double motor_lift_anti_blocking_speed_threshold_per_period = 0.3;
-constexpr double motor_lift_anti_blocking_error_threshold_per_period = 0.02;
-constexpr double motor_lift_anti_blocking_blocked_cycles_nb_threshold = 10;
-constexpr double motor_lift_min_speed_motor_lift_m_per_s = 0;
-constexpr double motor_lift_max_init_speed_motor_lift_m_per_s = 0.02;
-constexpr double motor_lift_max_speed_motor_lift_m_per_s = 0.17;
-constexpr double motor_lift_max_acc_motor_lift_m_per_s2 = motor_lift_max_speed_motor_lift_m_per_s * 10;
-constexpr double motor_lift_max_dec_motor_lift_m_per_s2 = motor_lift_max_speed_motor_lift_m_per_s * 2;
-constexpr double motor_lift_max_acc_motor_lift_mm_per_period2 = (
+constexpr float motor_lift_anti_blocking_speed_threshold_per_period = 0.3;
+constexpr float motor_lift_anti_blocking_error_threshold_per_period = 0.02;
+constexpr float motor_lift_anti_blocking_blocked_cycles_nb_threshold = 10;
+constexpr float motor_lift_min_speed_motor_lift_m_per_s = 0;
+constexpr float motor_lift_max_init_speed_motor_lift_m_per_s = 0.02;
+constexpr float motor_lift_max_speed_motor_lift_m_per_s = 0.17;
+constexpr float motor_lift_max_acc_motor_lift_m_per_s2 = motor_lift_max_speed_motor_lift_m_per_s * 10;
+constexpr float motor_lift_max_dec_motor_lift_m_per_s2 = motor_lift_max_speed_motor_lift_m_per_s * 2;
+constexpr float motor_lift_max_acc_motor_lift_mm_per_period2 = (
     (1000 * motor_lift_max_acc_motor_lift_m_per_s2 * motor_lift_control_thread_period_ms * motor_lift_control_thread_period_ms) \
     / (1000 * 1000)
     );          ///< Maximum motor_lift acceleration (mm/<motor_lift_control_thread_period_ms>²)
-constexpr double motor_lift_max_dec_motor_lift_mm_per_period2 = (
+constexpr float motor_lift_max_dec_motor_lift_mm_per_period2 = (
     (1000 * motor_lift_max_dec_motor_lift_m_per_s2 * motor_lift_control_thread_period_ms * motor_lift_control_thread_period_ms) \
     / (1000 * 1000)
     );          ///< Maximum motor_lift deceleration (mm/<motor_lift_control_thread_period_ms>²)
-constexpr double motor_lift_min_speed_motor_lift_mm_per_period = (
+constexpr float motor_lift_min_speed_motor_lift_mm_per_period = (
     (1000 * motor_lift_min_speed_motor_lift_m_per_s * motor_lift_control_thread_period_ms) \
     / 1000);    ///< Minimum motor_lift speed (mm/<motor_lift_control_thread_period_ms>)
-constexpr double motor_lift_max_speed_motor_lift_mm_per_period = (
+constexpr float motor_lift_max_speed_motor_lift_mm_per_period = (
     (1000 * motor_lift_max_speed_motor_lift_m_per_s * motor_lift_control_thread_period_ms) \
     / 1000);    ///< Maximum motor_lift speed (mm/<motor_lift_control_thread_period_ms>)
-constexpr double motor_lift_max_init_speed_motor_lift_mm_per_period = (
+constexpr float motor_lift_max_init_speed_motor_lift_mm_per_period = (
     (1000 * motor_lift_max_init_speed_motor_lift_m_per_s * motor_lift_control_thread_period_ms) \
     / 1000);    ///< Maximum motor_lift init speed (mm/<motor_lift_control_thread_period_ms>)
 

--- a/platforms/pf-robot-motors/pf_positional_actuators.cpp
+++ b/platforms/pf-robot-motors/pf_positional_actuators.cpp
@@ -194,24 +194,24 @@ static void *_positional_actuators_timeout_thread(void *args)
 }
 
 /// Update current speed from quadrature encoders measure.
-static void pf_motor_encoder_read_bottom_lift(double &current_speed)
+static void pf_motor_encoder_read_bottom_lift(float &current_speed)
 {
     current_speed = (qdec_read_and_reset(MOTOR_BOTTOM_LIFT_ID) * QDEC_BOTTOM_LIFT_POLARITY) / pulse_per_mm;
 }
 
 /// Update current speed from quadrature encoders measure.
-static void pf_motor_encoder_read_top_lift(double &current_speed)
+static void pf_motor_encoder_read_top_lift(float &current_speed)
 {
     current_speed = (qdec_read_and_reset(MOTOR_TOP_LIFT_ID) * QDEC_TOP_LIFT_POLARITY) / pulse_per_mm;
 }
 
-static void compute_current_speed_and_pose_bottom_lift(double &current_speed, double &current_pose)
+static void compute_current_speed_and_pose_bottom_lift(float &current_speed, float &current_pose)
 {
     pf_motor_encoder_read_bottom_lift(current_speed);
     current_pose += current_speed;
 }
 
-static void compute_current_speed_and_pose_top_lift(double &current_speed, double &current_pose)
+static void compute_current_speed_and_pose_top_lift(float &current_speed, float &current_pose)
 {
     pf_motor_encoder_read_top_lift(current_speed);
     current_pose += current_speed;


### PR DESCRIPTION
While the RAM savings are minimal, using float instead of double aligns
better with the STM32G474RE’s FPU capabilities, avoiding unnecessary
software emulation and improving computation efficiency.