### PR TITLE
191 fix robot is not moving anymore after a reset on same strategy

### DIFF
--- a/boards/cogip-native/Makefile.dep
+++ b/boards/cogip-native/Makefile.dep
@@ -1,14 +1,7 @@
-# vl53l0x-api is emulated, thus remove it from packages list
-USEPKG := $(filter-out vl53l0x-api,$(USEPKG))
-
 USEMODULE += periph_common
 
 ifneq (,$(filter periph_gpio,$(USEMODULE)))
   USEMODULE += periph_gpio_mock
-endif
-
-ifneq (,$(filter mtd,$(USEMODULE)))
-  USEMODULE += mtd_native
 endif
 
 ifneq (,$(filter periph_can,$(FEATURES_USED)))
@@ -20,5 +13,3 @@ ifneq (,$(filter periph_can,$(FEATURES_USED)))
 endif
 
 USEMODULE += native_drivers
-USEMODULE += pcf8575
-USEMODULE += pcf857x_irq

--- a/boards/cogip-native/Makefile.features
+++ b/boards/cogip-native/Makefile.features
@@ -8,9 +8,5 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_qdec
-FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-
-# Various other features (if any)
-FEATURES_PROVIDED += netif_ethernet

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -578,11 +578,6 @@ void pf_handle_target_pose(cogip::canpb::ReadBuffer &buffer)
     // Target pose
     target_pose.pb_read(pb_path_target_pose);
 
-    // If target pose has not changed, just do nothing
-    if (target_pose == previous_target_pose) {
-        return;
-    }
-
     // Target speed
     target_speed.set_distance((platform_max_speed_linear_mm_per_period * target_pose.max_speed_ratio_linear()) / 100);
     target_speed.set_angle((platform_max_speed_angular_deg_per_period * target_pose.max_speed_ratio_angular()) / 100);


### PR DESCRIPTION
Reproduce issue via interface (web or monitor):

* Select Back & Forth strategy
* Trigger a Next (wait or not for motion to complete)
* Press Reset
* Trigger another Next => robot no longer moves

Because if the target pose is identical to previous one, triggering a
check that skips motion when no change is detected leads to blocked
robot as it will never enable the motion control platform engine.