### PR TITLE
platforms/pf-robot-motion-control: split brake and end-game callbacks

### DIFF
--- a/platforms/pf-robot-motion-control/include/motion_control.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control.hpp
@@ -70,6 +70,9 @@ constexpr double platform_linear_anti_blocking_error_threshold_mm_per_period
 /// Handle brake signal to stop the robot
 void pf_handle_brake(cogip::canpb::ReadBuffer &buffer);
 
+/// Handle game end signal to stop the robot
+void pf_handle_game_end(cogip::canpb::ReadBuffer &buffer);
+
 /// Get pose to reach from protobuf message
 void pf_handle_target_pose(cogip::canpb::ReadBuffer &buffer);
 

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -570,6 +570,12 @@ void pf_send_pb_state(void)
 
 void pf_handle_brake([[maybe_unused]] cogip::canpb::ReadBuffer &buffer) {
     pf_motion_control_platform_engine.set_target_speed({0, 0});
+    reset_speed_pids();
+    pose_straight_filter.force_finished_state();
+}
+
+void pf_handle_game_end([[maybe_unused]] cogip::canpb::ReadBuffer &buffer) {
+    pf_motion_control_platform_engine.set_target_speed({0, 0});
 
     // Reset previous speed orders
     angular_speed_filter.reset_previous_speed_order();

--- a/platforms/pf-robot-motion-control/platform.cpp
+++ b/platforms/pf-robot-motion-control/platform.cpp
@@ -86,7 +86,7 @@ static void _handle_game_reset([[maybe_unused]] cogip::canpb::ReadBuffer & buffe
 /// Start threading sending actuators state.
 static void _handle_game_end([[maybe_unused]] cogip::canpb::ReadBuffer & buffer)
 {
-    cogip::pf::motion_control::pf_handle_brake(buffer);
+    cogip::pf::motion_control::pf_handle_game_end(buffer);
 }
 
 void _handle_copilot_connected(cogip::canpb::ReadBuffer &)


### PR DESCRIPTION
Separate brake and game end actions by introducing a game end callback

Previously, the braking action was triggered at game end, but the firmware must keep motion control enabled in the brake case. This separation allows precise and independent control of both behaviors.