### PR TITLE
motion_control: fix "error getting pose_reached" by initializing IO and improving enum handling

### DIFF
--- a/motion_control/engines/platform_engine/PlatformEngine.cpp
+++ b/motion_control/engines/platform_engine/PlatformEngine.cpp
@@ -56,6 +56,17 @@ void PlatformEngine::prepare_inputs()
     // Motion direction
     io_.set("motion_direction", target_pose_.get_motion_direction());
 
+    // Initialize pose_reached to moving (will be updated by PoseStraightFilter)
+    io_.set("pose_reached", target_pose_status_t::moving);
+
+    // Initialize speed commands to 0 (will be updated by SpeedPIDController)
+    io_.set("linear_speed_command", 0.0f);
+    io_.set("angular_speed_command", 0.0f);
+
+    // Initialize speed orders to 0 (will be updated by PosePIDController or FeedforwardCombiner)
+    io_.set("linear_speed_order", 0.0f);
+    io_.set("angular_speed_order", 0.0f);
+
     // Mark measured values read‑only:
     io_.mark_readonly("motion_direction");
     io_.mark_readonly("current_pose_x");


### PR DESCRIPTION
- Initialize pose_reached to moving in PlatformEngine::prepare_inputs() so the key exists before process_outputs() reads it
- Store enums as int in ControllersIO variant instead of target_pose_status_t directly
- Update get_as<>() to retrieve enums by fetching int and casting to the requested enum type
- Increase MAX_PARAMS from 32 to 48