### PR TITLE
213 add settings partition to store key value pair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ make -j$(nproc) -C examples/motion_control_robot_test
 
 ## Important Notes
 - Always ensure RIOT patches are applied before building
-- The project uses C++17 standard
+- The project uses C++20 standard
 - Default log level is set to LOG_ERROR
 - Main thread stack size is 8192 bytes
 - ISR stack size is 2048 bytes (increased for libstdc++)

--- a/Makefile.include
+++ b/Makefile.include
@@ -49,9 +49,13 @@ EXTERNAL_MODULE_DIRS += $(MCUFW_MODULE_DIRS:%=$(MCUFIRMWAREBASE)/%/)
 
 # Use C++20 by default
 CXXEXFLAGS := $(filter-out -std=%, $(CXXEXFLAGS))
-CXXEXFLAGS += -std=c++17
+CXXEXFLAGS += -std=c++20
 CXXEXFLAGS += -Wno-pedantic
 CXXEXFLAGS += -Wno-cast-align
+# RIOT headers use compound assignments on volatile-qualified registers
+# (e.g. SCB->SCR |= ...), deprecated in C++20 (P1152). RIOT is vendored and
+# not modified locally, so silence the warning for our C++ build only.
+CXXEXFLAGS += -Wno-volatile
 
 # MCU firmware version: <application>@<branch-name>-g<short-sha>[-dirty]
 MCU_FW_GIT_VERSION := $(shell git describe --long --tags --always --dirty --all | sed -E -e 's/^(heads|tags)\///' -e 's/^remotes\/origin\///' -e 's/\//-/g')

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To install toolchain and development on ubuntu 20.04:
 ```bash
 $ sudo apt install build-essential gcc-multilib g++-multilib openocd
 ```
-Minimal gcc version: 8.1
+Minimal gcc version: 10 (11+ recommended for full C++20 support)
 
 To manually install arm-none-eabi toolchain:
 ```bash

--- a/applications/robot-motion-control/include/robot1_conf.hpp
+++ b/applications/robot-motion-control/include/robot1_conf.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-// Project includes
 #include "etl/numeric.h"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 1
 #define MOTOR_RIGHT 0
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{-1.0};
+constexpr float default_qdec_left_polarity = 1.0;
+constexpr float default_qdec_right_polarity = -1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 50.8;
@@ -24,27 +20,27 @@ constexpr float min_motor_speed_percent = 10;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders Parameters
-inline Parameter<float> left_encoder_wheels_diameter_mm{47.64768795921133};
-inline Parameter<float> right_encoder_wheels_diameter_mm{47.792104995747586};
-inline Parameter<float> encoder_wheels_distance_mm{275.7117596881151};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{4096 * 4};
+constexpr float default_left_encoder_wheels_diameter_mm = 47.64768795921133;
+constexpr float default_right_encoder_wheels_diameter_mm = 47.792104995747586;
+constexpr float default_encoder_wheels_distance_mm = 275.7117596881151;
+constexpr float default_encoder_wheels_resolution_pulses = 4096 * 4;
 
 // Linear pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0};
+constexpr float default_linear_pose_pid_kp = 0.2;
+constexpr float default_linear_pose_pid_ki = 0;
+constexpr float default_linear_pose_pid_kd = 0;
 // Angular pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0};
+constexpr float default_angular_pose_pid_kp = 0.1;
+constexpr float default_angular_pose_pid_ki = 0;
+constexpr float default_angular_pose_pid_kd = 0;
 // Linear speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_speed_pid_kp{3.};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{0.8};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0};
+constexpr float default_linear_speed_pid_kp = 3.;
+constexpr float default_linear_speed_pid_ki = 0.8;
+constexpr float default_linear_speed_pid_kd = 0;
 // Angular speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_speed_pid_kp{5.5};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{0.6};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
+constexpr float default_angular_speed_pid_kp = 5.5;
+constexpr float default_angular_speed_pid_ki = 0.6;
+constexpr float default_angular_speed_pid_kd = 0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
@@ -52,21 +48,21 @@ inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
 // Ki helps eliminate steady-state error when tracker profile ends
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.3};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.3;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{3};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{0.8};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 3;
+constexpr float default_tracker_linear_speed_pid_ki = 0.8;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{5.5};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{0.6};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 5.5;
+constexpr float default_tracker_angular_speed_pid_ki = 0.6;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 2;
@@ -103,29 +99,28 @@ constexpr bool platform_linear_antiblocking = true;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-// Tracker linear pose PID integral limit
-// Limit = max_speed / ki to prevent integral windup
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_pose_pid_ki.get()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    (default_tracker_linear_pose_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_pose_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot1_conf.hpp
+++ b/applications/robot-motion-control/include/robot1_conf.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-// Project includes
-#include "board.h"
-#include "encoder/EncoderQDEC.hpp"
 #include "etl/numeric.h"
-#include "localization/LocalizationDifferential.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 1
 #define MOTOR_RIGHT 0
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{-1.0};
+constexpr float default_qdec_left_polarity = 1.0;
+constexpr float default_qdec_right_polarity = -1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 50.8;
@@ -27,27 +20,27 @@ constexpr float min_motor_speed_percent = 10;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders Parameters
-inline Parameter<float> left_encoder_wheels_diameter_mm{47.64768795921133};
-inline Parameter<float> right_encoder_wheels_diameter_mm{47.792104995747586};
-inline Parameter<float> encoder_wheels_distance_mm{275.7117596881151};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{4096 * 4};
+constexpr float default_left_encoder_wheels_diameter_mm = 47.64768795921133;
+constexpr float default_right_encoder_wheels_diameter_mm = 47.792104995747586;
+constexpr float default_encoder_wheels_distance_mm = 275.7117596881151;
+constexpr float default_encoder_wheels_resolution_pulses = 4096 * 4;
 
 // Linear pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0};
+constexpr float default_linear_pose_pid_kp = 0.2;
+constexpr float default_linear_pose_pid_ki = 0;
+constexpr float default_linear_pose_pid_kd = 0;
 // Angular pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0};
+constexpr float default_angular_pose_pid_kp = 0.1;
+constexpr float default_angular_pose_pid_ki = 0;
+constexpr float default_angular_pose_pid_kd = 0;
 // Linear speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_speed_pid_kp{3.};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{0.8};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0};
+constexpr float default_linear_speed_pid_kp = 3.;
+constexpr float default_linear_speed_pid_ki = 0.8;
+constexpr float default_linear_speed_pid_kd = 0;
 // Angular speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_speed_pid_kp{5.5};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{0.6};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
+constexpr float default_angular_speed_pid_kp = 5.5;
+constexpr float default_angular_speed_pid_ki = 0.6;
+constexpr float default_angular_speed_pid_kd = 0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
@@ -55,21 +48,21 @@ inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
 // Ki helps eliminate steady-state error when tracker profile ends
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.3};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.3;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{3};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{0.8};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 3;
+constexpr float default_tracker_linear_speed_pid_ki = 0.8;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{5.5};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{0.6};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 5.5;
+constexpr float default_tracker_angular_speed_pid_ki = 0.6;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 2;
@@ -106,44 +99,28 @@ constexpr bool platform_linear_antiblocking = true;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-// Tracker linear pose PID integral limit
-// Limit = max_speed / ki to prevent integral windup
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_pose_pid_ki.get()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
-// ============================================================================
-// Localization (encoder-based differential odometry)
-// ============================================================================
-
-static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
-                                                encoder_wheels_resolution_pulses.get());
-static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
-                                                 encoder_wheels_resolution_pulses.get());
-
-static cogip::localization::LocalizationDifferentialParameters
-    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
-                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
-static cogip::localization::LocalizationDifferential
-    robot_localization(localization_params, left_encoder, right_encoder);
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    (default_tracker_linear_pose_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_pose_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot2_conf.hpp
+++ b/applications/robot-motion-control/include/robot2_conf.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-// Project includes
 #include "etl/numeric.h"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -24,27 +20,27 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker pose PID gains (QUADPID_TRACKER - tracker branch)
@@ -52,21 +48,21 @@ inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
 // ============================================================================
 
 // Tracker linear pose PID (tracker, uses Ki for steady-state error elimination)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.09};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.05};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.09;
+constexpr float default_tracker_linear_pose_pid_ki = 0.05;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{5};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{0.3};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 5;
+constexpr float default_tracker_linear_speed_pid_ki = 0.3;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -96,34 +92,33 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-// Limit = max_speed / ki to prevent integral windup
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_pose_pid_ki.get()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
+
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
+
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    (default_tracker_linear_pose_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_pose_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot2_conf.hpp
+++ b/applications/robot-motion-control/include/robot2_conf.hpp
@@ -2,19 +2,14 @@
 
 // Project includes
 #include "etl/numeric.h"
-#include "localization/LocalizationOTOS.hpp"
-#include "otos/OTOS.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 1
 #define MOTOR_RIGHT 0
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{-1.0};
+constexpr float default_qdec_left_polarity = 1.0;
+constexpr float default_qdec_right_polarity = -1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -29,27 +24,27 @@ constexpr float min_motor_speed_percent = 7.5;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders Parameters
-inline Parameter<float> left_encoder_wheels_diameter_mm{47.64768795921133};
-inline Parameter<float> right_encoder_wheels_diameter_mm{47.792104995747586};
-inline Parameter<float> encoder_wheels_distance_mm{275.7117596881151};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{4096 * 4};
+constexpr float default_left_encoder_wheels_diameter_mm = 47.64768795921133;
+constexpr float default_right_encoder_wheels_diameter_mm = 47.792104995747586;
+constexpr float default_encoder_wheels_distance_mm = 275.7117596881151;
+constexpr float default_encoder_wheels_resolution_pulses = 4096 * 4;
 
 // Linear pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0};
+constexpr float default_linear_pose_pid_kp = 0.1;
+constexpr float default_linear_pose_pid_ki = 0;
+constexpr float default_linear_pose_pid_kd = 0;
 // Angular pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0};
+constexpr float default_angular_pose_pid_kp = 0.2;
+constexpr float default_angular_pose_pid_ki = 0;
+constexpr float default_angular_pose_pid_kd = 0;
 // Linear speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_speed_pid_kp{7};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{0.4};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0};
+constexpr float default_linear_speed_pid_kp = 7;
+constexpr float default_linear_speed_pid_ki = 0.4;
+constexpr float default_linear_speed_pid_kd = 0;
 // Angular speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_speed_pid_kp{4.5};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{0.125};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
+constexpr float default_angular_speed_pid_kp = 4.5;
+constexpr float default_angular_speed_pid_ki = 0.125;
+constexpr float default_angular_speed_pid_kd = 0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
@@ -57,21 +52,21 @@ inline Parameter<float, NonNegative> angular_speed_pid_kd{0};
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
 // Ki helps eliminate steady-state error when tracker profile ends
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.15};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.15;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.125};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.125;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{7};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{0.4};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 7;
+constexpr float default_tracker_linear_speed_pid_ki = 0.4;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{4.5};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{0.125};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 4.5;
+constexpr float default_tracker_angular_speed_pid_ki = 0.125;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 3;
@@ -108,59 +103,47 @@ constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{
-    static_cast<float>(etl::numeric_limits<int16_t>::max())};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{
-    static_cast<float>(etl::numeric_limits<int16_t>::max())};
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    static_cast<float>(etl::numeric_limits<int16_t>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    static_cast<float>(etl::numeric_limits<int16_t>::max());
 
-// Tracker linear pose PID integral limit
-// Limit = max_speed / ki to prevent integral windup
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_pose_pid_ki.get()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    (default_tracker_linear_pose_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_pose_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
 
 // ============================================================================
 // Localization (OTOS optical tracking sensor)
 // ============================================================================
 
-/// @brief Marker macro used by the parameter handler to decide whether to
-/// register the OTOS calibration scalars in the CAN parameter registry.
+/// @brief Marker macro picked up by motion_control_parameters.hpp and
+/// motion_control.cpp to select the OTOS localization path at build time.
 #define ROBOT_HAS_OTOS 1
 
 // OTOS I2C address
 constexpr uint8_t otos_i2c_addr = 0x17;
 
-// OTOS calibration scalars (range 0.872 to 1.127). Exposed as live
-// Parameter<float> so they can be calibrated and updated at runtime via
-// the CAN parameter handler.
-inline Parameter<float> otos_linear_scalar{0.969f};
-inline Parameter<float> otos_angular_scalar{0.994f};
+// OTOS calibration scalar defaults (range [0.872, 1.127]).
+constexpr float default_otos_linear_scalar = 0.969f;
+constexpr float default_otos_angular_scalar = 0.994f;
 
 // OTOS mounting offset relative to robot center (mm, degrees). Physical
 // mounting geometry, calibrated at assembly, no runtime tuning.
 constexpr float otos_offset_x_mm = 0.0f;
 constexpr float otos_offset_y_mm = 0.0f;
 constexpr float otos_offset_h_deg = 0.0f;
-
-static cogip::localization::LocalizationOTOS::Parameters
-    otos_params(otos_linear_scalar, otos_angular_scalar, otos_offset_x_mm, otos_offset_y_mm,
-                otos_offset_h_deg);
-
-static cogip::otos::OTOS otos_sensor(SOFT_I2C_DEV(0), otos_i2c_addr);
-static cogip::localization::LocalizationOTOS robot_localization(otos_sensor, otos_params);

--- a/applications/robot-motion-control/include/robot3_conf.hpp
+++ b/applications/robot-motion-control/include/robot3_conf.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-// Project includes
-#include "board.h"
-#include "encoder/EncoderQDEC.hpp"
 #include "etl/numeric.h"
-#include "localization/LocalizationDifferential.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -27,49 +20,49 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker pose PID gains (QUADPID_TRACKER - tracker branch)
 // Used to track the motion profile in real-time (closed-loop tracking)
 // ============================================================================
 
-// Tracker linear pose PID (tracker, uses Ki for steady-state error elimination)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.09};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.05};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
-// Tracker angular pose PID (tracker)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+// Tracker linear pose PID (tracker during MOVE_TO_POSITION)
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
+// Tracker angular pose PID (tracker during ROTATE states)
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{5};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{0.3};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -99,49 +92,31 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-// Limit = max_speed / ki to prevent integral windup
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_pose_pid_ki.get()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// ============================================================================
-// Localization (encoder-based differential odometry)
-// ============================================================================
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
-                                                encoder_wheels_resolution_pulses.get());
-static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
-                                                 encoder_wheels_resolution_pulses.get());
-
-static cogip::localization::LocalizationDifferentialParameters
-    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
-                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
-static cogip::localization::LocalizationDifferential
-    robot_localization(localization_params, left_encoder, right_encoder);
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot3_conf.hpp
+++ b/applications/robot-motion-control/include/robot3_conf.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-// Project includes
 #include "etl/numeric.h"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -24,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -95,33 +91,31 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
+
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
+
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot4_conf.hpp
+++ b/applications/robot-motion-control/include/robot4_conf.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-// Project includes
-#include "board.h"
-#include "encoder/EncoderQDEC.hpp"
 #include "etl/numeric.h"
-#include "localization/LocalizationDifferential.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -27,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 13;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -98,48 +91,31 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// ============================================================================
-// Localization (encoder-based differential odometry)
-// ============================================================================
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
-                                                encoder_wheels_resolution_pulses.get());
-static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
-                                                 encoder_wheels_resolution_pulses.get());
-
-static cogip::localization::LocalizationDifferentialParameters
-    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
-                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
-static cogip::localization::LocalizationDifferential
-    robot_localization(localization_params, left_encoder, right_encoder);
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot4_conf.hpp
+++ b/applications/robot-motion-control/include/robot4_conf.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-// Project includes
 #include "etl/numeric.h"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -24,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{13};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 13;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -95,33 +91,31 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
+
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
+
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot5_conf.hpp
+++ b/applications/robot-motion-control/include/robot5_conf.hpp
@@ -1,18 +1,14 @@
 #pragma once
 
-// Project includes
 #include "etl/numeric.h"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -24,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -95,33 +91,29 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
+
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
+
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot5_conf.hpp
+++ b/applications/robot-motion-control/include/robot5_conf.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-// Project includes
-#include "board.h"
-#include "encoder/EncoderQDEC.hpp"
 #include "etl/numeric.h"
-#include "localization/LocalizationDifferential.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -27,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{13};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -98,48 +91,29 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<uint16_t>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// ============================================================================
-// Localization (encoder-based differential odometry)
-// ============================================================================
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
-                                                encoder_wheels_resolution_pulses.get());
-static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
-                                                 encoder_wheels_resolution_pulses.get());
-
-static cogip::localization::LocalizationDifferentialParameters
-    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
-                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
-static cogip::localization::LocalizationDifferential
-    robot_localization(localization_params, left_encoder, right_encoder);
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot6_conf.hpp
+++ b/applications/robot-motion-control/include/robot6_conf.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-// Project includes
-#include "board.h"
-#include "encoder/EncoderQDEC.hpp"
 #include "etl/numeric.h"
-#include "localization/LocalizationDifferential.hpp"
-#include "parameter/Parameter.hpp"
-
-using namespace cogip::parameter;
 
 /* Motion motors */
 #define MOTOR_LEFT 0
 #define MOTOR_RIGHT 1
 
 /* Quadrature decoding polarity */
-inline Parameter<float, ReadOnly> qdec_left_polarity{-1.0};
-inline Parameter<float, ReadOnly> qdec_right_polarity{1.0};
+constexpr float default_qdec_left_polarity = -1.0;
+constexpr float default_qdec_right_polarity = 1.0;
 
 /// Motors properties
 constexpr float motor_wheels_diameter_mm = 60.0;
@@ -27,48 +20,48 @@ constexpr float min_motor_speed_percent = 0;
 constexpr float max_motor_speed_percent = 100;
 
 /// Encoders properties
-inline Parameter<float> left_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{motor_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{motor_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{16 * 4 * 8};
+constexpr float default_left_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_right_encoder_wheels_diameter_mm = motor_wheels_diameter_mm;
+constexpr float default_encoder_wheels_distance_mm = motor_wheels_distance_mm;
+constexpr float default_encoder_wheels_resolution_pulses = 16 * 4 * 8;
 
 // Linear pose PID
-inline Parameter<float, NonNegative> linear_pose_pid_kp{1};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{0.0};
+constexpr float default_linear_pose_pid_kp = 1;
+constexpr float default_linear_pose_pid_ki = 0.0;
+constexpr float default_linear_pose_pid_kd = 0.0;
 // Angular pose PID
-inline Parameter<float, NonNegative> angular_pose_pid_kp{1};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{0.0};
+constexpr float default_angular_pose_pid_kp = 1;
+constexpr float default_angular_pose_pid_ki = 0.0;
+constexpr float default_angular_pose_pid_kd = 0.0;
 // Linear speed PID
-inline Parameter<float, NonNegative> linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{0.0};
+constexpr float default_linear_speed_pid_kp = 10;
+constexpr float default_linear_speed_pid_ki = 1;
+constexpr float default_linear_speed_pid_kd = 0.0;
 // Angular speed PID
-inline Parameter<float, NonNegative> angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{0.0};
+constexpr float default_angular_speed_pid_kp = 10;
+constexpr float default_angular_speed_pid_ki = 1;
+constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
 // Tracker chain PID gains (QUADPID_TRACKER)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{0.1};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{0.0};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{0};
+constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_ki = 0.0;
+constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{0.2};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{0};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{0};
+constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_ki = 0;
+constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{0};
+constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_ki = 1;
+constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{10};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{1};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{0};
+constexpr float default_tracker_angular_speed_pid_kp = 10;
+constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // Linear threshold
 constexpr float linear_threshold = 5;
@@ -98,48 +91,29 @@ constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 constexpr float speed_clamp_ratio = 1.2f;
 constexpr float acceleration_clamp_ratio = 1.2f;
 
-// Linear pose PID integral limit
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Angular pose PID integral limit
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Linear speed PID integral limit
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{max_speed_mm_per_s /
-                                                                     linear_speed_pid_ki.get()};
-// Angular speed PID integral limit
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{max_speed_deg_per_s /
-                                                                      angular_speed_pid_ki.get()};
-
-// Tracker linear pose PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Tracker angular pose PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{
-    etl::numeric_limits<float>::max()};
-// Tracker linear speed PID integral limit
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{
-    max_speed_mm_per_s / tracker_linear_speed_pid_ki.get()};
-// Tracker angular speed PID integral limit
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{
-    max_speed_deg_per_s / tracker_angular_speed_pid_ki.get()};
-
 // Linear antiblocking
 constexpr bool platform_linear_antiblocking = false;
 // Angular antiblocking
 constexpr bool angular_antiblocking = false;
 
-// ============================================================================
-// Localization (encoder-based differential odometry)
-// ============================================================================
+// PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_linear_speed_pid_integral_limit =
+    (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
+                                       : (etl::numeric_limits<float>::max());
+constexpr float default_angular_speed_pid_integral_limit =
+    (default_angular_speed_pid_ki != 0) ? (max_speed_deg_per_s / default_angular_speed_pid_ki)
+                                        : (etl::numeric_limits<float>::max());
 
-static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
-                                                encoder_wheels_resolution_pulses.get());
-static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
-                                                 encoder_wheels_resolution_pulses.get());
-
-static cogip::localization::LocalizationDifferentialParameters
-    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
-                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
-static cogip::localization::LocalizationDifferential
-    robot_localization(localization_params, left_encoder, right_encoder);
+// Tracker PID integral limits
+constexpr float default_tracker_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit =
+    (default_tracker_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_angular_speed_pid_integral_limit =
+    (default_tracker_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());

--- a/boards/cogip-board/Makefile.dep
+++ b/boards/cogip-board/Makefile.dep
@@ -6,3 +6,10 @@ endif
 DISABLE_MODULE += periph_init_i2c
 
 USEMODULE += mpu_stack_guard
+
+# FlashDB modules
+USEMODULE += flashdb_kvdb          # Key-Value database module
+USEMODULE += flashdb_mtd           # MTD backend for FlashDB
+
+# MTD(Memory Technology Device) driver
+USEMODULE += mtd_flashpage # Use internal flash via flashpage interface

--- a/boards/cogip-board/Makefile.features
+++ b/boards/cogip-board/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32g474re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_can
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm

--- a/boards/cogip-board/Makefile.include
+++ b/boards/cogip-board/Makefile.include
@@ -9,3 +9,25 @@ include $(RIOTMAKE)/boards/stm32.inc.mk
 
 # Set onboard transceiver loop delay
 CFLAGS += -DCONFIG_FDCAN_DEVICE_TRANSCEIVER_LOOP_DELAY=130
+
+# FlashDB configuration
+# STM32G474RE has 64-bit (doubleword) flash write granularity
+CFLAGS += -DFDB_WRITE_GRAN=64
+
+# Reserve the last 8 flash pages (16 KiB) for the FlashDB KV settings region.
+# Value = 8 pages * 2048 B (FLASHPAGE_SIZE on STM32G474RE). Must stay in sync
+# with MTD_SETTINGS_SECTOR_COUNT * FLASHPAGE_SIZE in include/mtd_conf.h.
+MTD_SETTINGS_LEN := 16384
+
+# FAL (Flash Abstraction Layer) partition configuration for KVDB storage
+CFLAGS += -DFAL_PART0_LABEL=\"settings\"
+CFLAGS += -DFAL_PART0_LENGTH=$(MTD_SETTINGS_LEN)
+
+# Cap the firmware image so .text/.rodata/.data cannot grow into the KV
+# settings region at the top of flash. The cortexm linker script defines
+# the rom region as LENGTH = _fw_rom_length, so an oversized image fails
+# the link with "region rom overflowed". Without this cap, the flasher
+# would happily overwrite the settings pages and the first
+# FlashKVStorage::store() after boot would erase a sector containing
+# firmware code.
+FW_ROM_LEN = $$(( $(ROM_LEN_K) * 1024 - $(MTD_SETTINGS_LEN) ))

--- a/boards/cogip-board/Makefile.include
+++ b/boards/cogip-board/Makefile.include
@@ -9,3 +9,11 @@ include $(RIOTMAKE)/boards/stm32.inc.mk
 
 # Set onboard transceiver loop delay
 CFLAGS += -DCONFIG_FDCAN_DEVICE_TRANSCEIVER_LOOP_DELAY=130
+
+# FlashDB configuration
+# STM32G474RE has 64-bit (doubleword) flash write granularity
+CFLAGS += -DFDB_WRITE_GRAN=64
+
+# FAL (Flash Abstraction Layer) partition configuration for KVDB storage
+CFLAGS += -DFAL_PART0_LABEL=\"settings\"
+CFLAGS += -DFAL_PART0_LENGTH=8*2048

--- a/boards/cogip-board/board.c
+++ b/boards/cogip-board/board.c
@@ -21,6 +21,12 @@
 #include "board.h"
 #include <stdio.h>
 
+#include "mtd_conf.h"
+
+/* Instantiate the flashpage MTD device for settings storage */
+static mtd_flashpage_t mtd_settings = MTD_SETTINGS_INIT_VAL;
+MTD_XFA_ADD(mtd_settings, 0);
+
 /**
  * Start of the heap
  */

--- a/boards/cogip-board/include/board.h
+++ b/boards/cogip-board/include/board.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @defgroup    boards_cogip-board COGIP 20234
+ * @defgroup    boards_cogip-board COGIP 2024
  * @ingroup     boards_cogip-board
  * @brief       Support for the COGIP 2024
  * @{

--- a/boards/cogip-board/include/mtd_conf.h
+++ b/boards/cogip-board/include/mtd_conf.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 COGIP
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_cogip_board
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for persistent settings storage
+ *
+ * This file defines the MTD (Memory Technology Device) configuration
+ * for persistent key-value storage using FlashDB on the cogip-board.
+ *
+ * @author      Mathis LECRIVAIN <lecrivain.mathis@gmail.com>
+ */
+
+#ifndef MTD_SETTINGS_H
+#define MTD_SETTINGS_H
+
+#include "mtd_flashpage.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MTD Memory Technology Device interface configuration for settings storage
+ *
+ * Configuration for persistent key-value storage using FlashDB.
+ * Uses the last pages of internal flash memory (STM32G474RE).
+ *
+ * We cannot use MTD_FLASHPAGE_INIT_VAL() because it sets sector_count
+ * to FLASHPAGE_NUMOF (= entire flash, 256 sectors / 512 KB), which would
+ * expose the firmware code region to FlashDB. Instead we manually limit
+ * the device to 8 pages (16 KB).
+ *
+ * Memory layout (last 8 pages of flash):
+ * - Offset: FLASHPAGE_NUMOF - 8 = page 248 (on STM32G474RE)
+ * - Sector count: 8
+ * - Pages per sector: 1
+ * - Page size: 2048 bytes (hardware flash page size)
+ * - Total size: 8 × 2048 = 16 KB
+ *
+ * @{
+ */
+#define MTD_SETTINGS_SECTOR_COUNT (8)
+#define MTD_SETTINGS_PAGES_PER_SECTOR (1)
+#define MTD_SETTINGS_PAGE_SIZE (FLASHPAGE_SIZE)
+#define MTD_SETTINGS_OFFSET (FLASHPAGE_NUMOF - MTD_SETTINGS_SECTOR_COUNT)
+#define MTD_SETTINGS_INIT_VAL                                                                      \
+    {                                                                                              \
+        .base =                                                                                    \
+            {                                                                                      \
+                .driver = &mtd_flashpage_driver,                                                   \
+                .sector_count = MTD_SETTINGS_SECTOR_COUNT,                                         \
+                .pages_per_sector = MTD_SETTINGS_PAGES_PER_SECTOR,                                 \
+                .page_size = MTD_SETTINGS_PAGE_SIZE,                                               \
+                .write_size = 1,                                                                   \
+            },                                                                                     \
+        .offset = MTD_SETTINGS_OFFSET,                                                             \
+    }
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_SETTINGS_H */
+/** @} */

--- a/boards/cogip-board/include/periph_conf.h
+++ b/boards/cogip-board/include/periph_conf.h
@@ -30,6 +30,7 @@
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 #include "clk_conf.h"
+#include "mtd_conf.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus

--- a/boards/cogip-board/include/periph_conf.h
+++ b/boards/cogip-board/include/periph_conf.h
@@ -88,7 +88,9 @@ static const pwm_conf_t pwm_config[] = {
          {/* Left motor PWM */
           {.pin = GPIO_PIN(PORT_A, 8), .cc_chan = 0},
           /* Right motor PWM */
-          {.pin = GPIO_PIN(PORT_A, 9), .cc_chan = 1}},
+          {.pin = GPIO_PIN(PORT_A, 9), .cc_chan = 1},
+          {.pin = GPIO_UNDEF, .cc_chan = 0},
+          {.pin = GPIO_UNDEF, .cc_chan = 0}},
      .af = GPIO_AF6,
      .bus = APB2},
 };

--- a/boards/cogip-native/Makefile.dep
+++ b/boards/cogip-native/Makefile.dep
@@ -13,3 +13,10 @@ ifneq (,$(filter periph_can,$(FEATURES_USED)))
 endif
 
 USEMODULE += native_drivers
+
+# FlashDB modules
+USEMODULE += flashdb_kvdb          # Key-Value database module
+USEMODULE += flashdb_mtd           # MTD backend for FlashDB
+
+# MTD(Memory Technology Device) driver
+USEMODULE += mtd_emulated # Use emulated MTD in RAM for native

--- a/boards/cogip-native/Makefile.features
+++ b/boards/cogip-native/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += arch_64bit
 NATIVE_ARCH_BIT = 64
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm

--- a/boards/cogip-native/Makefile.include
+++ b/boards/cogip-native/Makefile.include
@@ -3,3 +3,8 @@ include $(RIOTBOARD)/common/native/Makefile.include
 
 # Set onboard transceiver loop delay, mandatory so set fake value
 CFLAGS += -DCONFIG_FDCAN_DEVICE_TRANSCEIVER_LOOP_DELAY=0
+
+# FlashDB FAL (Flash Abstraction Layer) partition configuration
+# Define partition for KVDB storage
+CFLAGS += -DFAL_PART0_LABEL=\"settings\"
+CFLAGS += -DFAL_PART0_LENGTH=8*2048

--- a/boards/cogip-native/board_init.c
+++ b/boards/cogip-native/board_init.c
@@ -20,6 +20,10 @@
 #include <unistd.h>
 
 #include "board_internal.h"
+#include "mtd_conf.h"
+
+/* Instantiate the emulated MTD device and register it in the XFA */
+MTD_SETTINGS_INIT_VAL;
 
 /**
  * malloc() memory overhead (size + next address)

--- a/boards/cogip-native/include/board.h
+++ b/boards/cogip-native/include/board.h
@@ -27,6 +27,7 @@
 #include <motor_driver.h>
 
 /* Project includes */
+#include "mtd_conf.h"
 #include "periph_conf.h"
 
 #ifdef __cplusplus

--- a/boards/cogip-native/include/mtd_conf.h
+++ b/boards/cogip-native/include/mtd_conf.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 COGIP
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_cogip_native
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for persistent settings storage
+ *
+ * This file defines the MTD (Memory Technology Device) configuration
+ * for persistent key-value storage using FlashDB on the cogip-native board.
+ *
+ * @author      Mathis LECRIVAIN <lecrivain.mathis@gmail.com>
+ */
+
+#ifndef MTD_SETTINGS_H
+#define MTD_SETTINGS_H
+
+#include "mtd.h"
+#include "mtd_emulated.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MTD Memory Technology Device interface configuration for settings storage
+ *
+ * Configuration for persistent key-value storage using FlashDB.
+ * Uses emulated MTD in RAM for native board (x86_64 simulation).
+ *
+ * Memory layout:
+ * - Number of sectors: 8
+ * - Pages per sector: 1
+ * - Page size: 2048 bytes
+ * - Total size: 16 KB
+ *
+ * @{
+ */
+#define MTD_SETTINGS_SECTOR_COUNT (8)
+#define MTD_SETTINGS_PAGE_SIZE (2048)
+#define MTD_SETTINGS_INIT_VAL                                                                      \
+    MTD_EMULATED_DEV(0, MTD_SETTINGS_SECTOR_COUNT, 1, MTD_SETTINGS_PAGE_SIZE)
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_SETTINGS_H */
+/** @} */

--- a/boards/cogip-native/include/mtd_conf.h
+++ b/boards/cogip-native/include/mtd_conf.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 COGIP
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_cogip_native
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for persistent settings storage
+ *
+ * This file defines the MTD (Memory Technology Device) configuration
+ * for persistent key-value storage using FlashDB on the cogip-native board.
+ *
+ * @author      Mathis LECRIVAIN <lecrivain.mathis@gmail.com>
+ */
+
+#ifndef MTD_SETTINGS_H
+#define MTD_SETTINGS_H
+
+#include "mtd.h"
+#include "mtd_emulated.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief MTD Memory Technology Device interface configuration for settings storage
+ *
+ * Configuration for persistent key-value storage using FlashDB.
+ * Uses emulated MTD in RAM for native board (x86_64 simulation).
+ *
+ * Memory layout:
+ * - Number of sectors: 8
+ * - Pages per sector: 1
+ * - Page size: 2048 bytes
+ * - Total size: 16 KB
+ *
+ * @{
+ */
+#define MTD_SETTINGS_SECTOR_COUNT (8)
+#define MTD_SETTINGS_PAGE_SIZE   (2048)
+#define MTD_SETTINGS_INIT_VAL    MTD_EMULATED_DEV(0, MTD_SETTINGS_SECTOR_COUNT, 1, MTD_SETTINGS_PAGE_SIZE)
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_SETTINGS_H */
+/** @} */

--- a/examples/parameter_demo/Makefile
+++ b/examples/parameter_demo/Makefile
@@ -3,5 +3,7 @@ APPLICATION = parameter_demo
 BOARD ?= cogip-native
 
 USEMODULE += parameter
+USEMODULE += flash_kv_storage
+USEMODULE += printf_float
 
 include ../../Makefile.include

--- a/examples/parameter_demo/main.cpp
+++ b/examples/parameter_demo/main.cpp
@@ -16,7 +16,9 @@
 #include "etl/array.h"
 #include "etl/map.h"
 #include "etl/string.h"
+#include "flash_kv_storage/FlashKVStorage.hpp"
 #include "parameter/Parameter.hpp"
+#include "parameter/StoragePolicies.hpp"
 
 using namespace cogip::parameter;
 using cogip::utils::operator"" _key_hash;
@@ -38,7 +40,7 @@ static Parameter<float> left_encoder_wheels_diameter_mm{47.8};
 static Parameter<float> right_encoder_wheels_diameter_mm{47.8};
 static Parameter<float> encoder_wheels_distance_mm{275};
 static Parameter<float> encoder_wheels_resolution_pulses{4096 * 4};
-static Parameter<float, WithBounds<0, 500>> max_angular_velocity_deg_s{180.0}; // With validation: 0-500°/s
+static Parameter<float, WithBounds<0, 500>, WithFlashStorage<KEY_MAX_ANGULAR_VELOCITY>> max_angular_velocity_deg_s{180.0}; // With validation + flash persistence
 static Parameter<bool> enable_logging{true};
 
 /// @brief Parameter registry mapping key hashes to parameter references
@@ -95,6 +97,18 @@ localizationParameters parameters(left_encoder_wheels_diameter_mm, right_encoder
 /// @return Always returns 0
 int main(void)
 {
+    // Initialize persistent storage (must happen before load() calls)
+    LOG_INFO("max_angular_velocity before load: %.1f\n", max_angular_velocity_deg_s.get());
+    if (cogip::flash_kv_storage::FlashKVStorage::instance().init() == 0) {
+        LOG_INFO("FlashKVStorage initialized successfully\n");
+        // Reload persistent parameters from flash
+        max_angular_velocity_deg_s.load();
+        LOG_INFO("max_angular_velocity after load: %.1f\n", max_angular_velocity_deg_s.get());
+    } else {
+        LOG_INFO("FlashKVStorage initialization failed\n");
+    }
+    LOG_INFO("\n");
+
     // clang-format off
     LOG_INFO("=== Compile-time Key Hashing ===\n");
     LOG_INFO("- 'left_wheel_diameter'_key_hash:  0x%08" PRIx32 "\n", KEY_LEFT_WHEEL_DIAMETER);
@@ -193,6 +207,41 @@ int main(void)
     LOG_INFO("- parameters.left_encoder_wheels_diameter_mm: %.2f mm\n",
              parameters.left_encoder_wheels_diameter_mm.get());
     LOG_INFO("\n");
+
+    // clang-format off
+    LOG_INFO("=== Flash Persistence (WithFlashStorage policy) ===\n");
+    LOG_INFO("- max_angular_velocity current value: %.1f (valid: %s)\n",
+             max_angular_velocity_deg_s.get(),
+             max_angular_velocity_deg_s.isValid() ? "yes" : "no");
+
+    // Set a new valid value (should be persisted to flash)
+    if (max_angular_velocity_deg_s.set(250.0f)) {
+        LOG_INFO("- Set max_angular_velocity to 250.0: SUCCESS (saved to flash)\n");
+    } else {
+        LOG_INFO("- Set max_angular_velocity to 250.0: FAILED\n");
+    }
+
+    // Try out-of-bounds value (should be rejected, flash NOT updated)
+    if (max_angular_velocity_deg_s.set(600.0f)) {
+        LOG_INFO("- Set max_angular_velocity to 600.0: SUCCESS\n");
+    } else {
+        LOG_INFO("- Set max_angular_velocity to 600.0: FAILED (exceeds upper bound 500, flash NOT updated)\n");
+    }
+    LOG_INFO("- max_angular_velocity after tests: %.1f\n", max_angular_velocity_deg_s.get());
+
+    // Verify persistence by reading back from flash directly
+    float readback = 0.0f;
+    int ret = cogip::flash_kv_storage::FlashKVStorage::instance().load(KEY_MAX_ANGULAR_VELOCITY,
+                                                                       readback);
+    if (ret == 0) {
+        LOG_INFO("- Flash readback: %.1f (matches current value: %s)\n", readback,
+                 (readback == max_angular_velocity_deg_s.get()) ? "yes" : "no");
+    } else {
+        LOG_INFO("- Flash readback: FAILED (no data in flash)\n");
+    }
+
+    LOG_INFO("\n");
+    // clang-format on
 
     // Protobuf conversion demonstration - Generic approach using registry
     // Shows how to build ParameterGetResponse messages (for CAN communication)

--- a/lib/flash_kv_storage/FlashKVStorage.cpp
+++ b/lib/flash_kv_storage/FlashKVStorage.cpp
@@ -1,0 +1,142 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_flash_kv_storage
+/// @{
+/// @file
+/// @brief      FlashKVStorage implementation — FlashDB KVDB singleton
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#include "flash_kv_storage/FlashKVStorage.hpp"
+
+#include <cstdio>
+
+#include "fal_cfg.h"
+#include "mtd.h"
+
+#ifndef FAL_MTD
+#error "FAL_MTD must be defined for FlashKVStorage"
+#endif
+#ifndef FAL_PART0_LABEL
+#error "FAL_PART0_LABEL must be defined in fal_cfg.h for FlashKVStorage"
+#endif
+#ifndef FAL_PART0_LENGTH
+#error "FAL_PART0_LENGTH must be defined in fal_cfg.h for FlashKVStorage"
+#endif
+
+extern "C" {
+// Initialize FlashDB MTD backend (defined in fal_mtd_port.c, no public header)
+void fdb_mtd_init(mtd_dev_t* mtd);
+}
+
+namespace cogip {
+namespace flash_kv_storage {
+
+void FlashKVStorage::fdb_lock(fdb_db_t db)
+{
+    mutex_lock(static_cast<mutex_t*>(db->user_data));
+}
+
+void FlashKVStorage::fdb_unlock(fdb_db_t db)
+{
+    mutex_unlock(static_cast<mutex_t*>(db->user_data));
+}
+
+FlashKVStorage::FlashKVStorage() : kvdb_{0}, kvdb_mutex_(MUTEX_INIT), initialized_(false) {}
+
+FlashKVStorage& FlashKVStorage::instance()
+{
+    static FlashKVStorage store;
+    return store;
+}
+
+int FlashKVStorage::init()
+{
+    if (initialized_) {
+        return 0;
+    }
+
+    // Initialize MTD device for FlashDB
+    fdb_mtd_init(FAL_MTD);
+
+    // Compute sector size from MTD geometry
+    uint32_t sec_size = FAL_MTD->pages_per_sector * FAL_MTD->page_size;
+    uint32_t db_size = FAL_PART0_LENGTH;
+
+    // Configure lock/unlock callbacks
+    mutex_init(&kvdb_mutex_);
+    fdb_kvdb_control(&kvdb_, FDB_KVDB_CTRL_SET_LOCK, reinterpret_cast<void*>(fdb_lock));
+    fdb_kvdb_control(&kvdb_, FDB_KVDB_CTRL_SET_UNLOCK, reinterpret_cast<void*>(fdb_unlock));
+
+    // Configure sector and database size
+    fdb_kvdb_control(&kvdb_, FDB_KVDB_CTRL_SET_SEC_SIZE, &sec_size);
+    fdb_kvdb_control(&kvdb_, FDB_KVDB_CTRL_SET_MAX_SIZE, &db_size);
+
+    // Initialize KVDB with partition label matching FAL_PART0_LABEL
+    fdb_err_t result = fdb_kvdb_init(&kvdb_, kDBName, FAL_PART0_LABEL, nullptr, &kvdb_mutex_);
+    if (result != FDB_NO_ERR) {
+        return -1;
+    }
+
+    initialized_ = true;
+
+    return 0;
+}
+
+void FlashKVStorage::hash_to_key(uint32_t key_hash, char* buf)
+{
+    snprintf(buf, 9, "%08x", static_cast<unsigned int>(key_hash));
+}
+
+int FlashKVStorage::store_blob(uint32_t key_hash, const void* data, size_t size)
+{
+    if (!initialized_) {
+        return -1;
+    }
+
+    char key[9];
+    hash_to_key(key_hash, key);
+
+    struct fdb_blob blob;
+    fdb_blob_make(&blob, data, size);
+    fdb_err_t result = fdb_kv_set_blob(&kvdb_, key, &blob);
+
+    return (result == FDB_NO_ERR) ? 0 : -1;
+}
+
+int FlashKVStorage::load_blob(uint32_t key_hash, void* data, size_t size)
+{
+    if (!initialized_) {
+        return -1;
+    }
+
+    char key[9];
+    hash_to_key(key_hash, key);
+
+    struct fdb_blob blob;
+    fdb_blob_make(&blob, data, size);
+    fdb_kv_get_blob(&kvdb_, key, &blob);
+
+    return (blob.saved.len == size) ? 0 : -1;
+}
+
+int FlashKVStorage::del(uint32_t key_hash)
+{
+    if (!initialized_) {
+        return -1;
+    }
+
+    char key[9];
+    hash_to_key(key_hash, key);
+
+    fdb_err_t result = fdb_kv_del(&kvdb_, key);
+
+    return (result == FDB_NO_ERR) ? 0 : -1;
+}
+
+} // namespace flash_kv_storage
+} // namespace cogip
+
+/// @}

--- a/lib/flash_kv_storage/Makefile
+++ b/lib/flash_kv_storage/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/lib/flash_kv_storage/Makefile.dep
+++ b/lib/flash_kv_storage/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += flashdb_kvdb
+USEMODULE += flashdb_mtd
+USEMODULE += core_mutex

--- a/lib/flash_kv_storage/Makefile.include
+++ b/lib/flash_kv_storage/Makefile.include
@@ -1,0 +1,2 @@
+USEMODULE_INCLUDES_flash_kv_storage := $(LAST_MAKEFILEDIR)/include
+USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_flash_kv_storage)

--- a/lib/flash_kv_storage/include/flash_kv_storage/FlashKVStorage.hpp
+++ b/lib/flash_kv_storage/include/flash_kv_storage/FlashKVStorage.hpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_flash_kv_storage
+/// @{
+/// @file
+/// @brief      Singleton FlashDB KVDB wrapper for persistent key-value storage
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <etl/type_traits.h>
+
+#include "flashdb.h"
+#include "mutex.h"
+
+namespace cogip {
+namespace flash_kv_storage {
+
+/// @brief Singleton wrapper around FlashDB KVDB for persistent parameter storage
+///
+/// @details Provides blob-level get/set/del operations keyed by 8-char hex strings
+///          derived from 32-bit parameter key hashes.
+///
+/// @note Initialization is explicit: call `init()` from `main()` after hardware is ready.
+///       Before `init()`, all operations silently return failure — this is safe for static
+///       `Parameter` objects that attempt `on_init` during construction before `main()`.
+class FlashKVStorage
+{
+  public:
+    /// @brief Get the singleton instance
+    /// @return Reference to the singleton FlashKVStorage
+    static FlashKVStorage& instance();
+
+    /// @brief Initialize the FlashDB KVDB backend
+    /// @return 0 on success, negative error code on failure
+    /// @note Must be called from `main()` after hardware init. Calling multiple times is safe.
+    int init();
+
+    /// @brief Check if the store has been initialized
+    /// @return true if init() has been called successfully
+    bool is_initialized() const
+    {
+        return initialized_;
+    }
+
+    /// @brief Store a trivially copyable value under the given key hash
+    /// @tparam T Value type (must be trivially copyable)
+    /// @param key_hash 32-bit parameter key hash
+    /// @param value Reference to the value to store
+    /// @return 0 on success, negative error code on failure
+    template <typename T> int store(uint32_t key_hash, const T& value)
+    {
+        static_assert(etl::is_trivially_copyable_v<T>, "T must be trivially copyable");
+        return store_blob(key_hash, &value, sizeof(T));
+    }
+
+    /// @brief Load a trivially copyable value for the given key hash
+    /// @tparam T Value type (must be trivially copyable)
+    /// @param key_hash 32-bit parameter key hash
+    /// @param value Reference to the value to load into
+    /// @return 0 on success, negative error code on failure or key not found
+    template <typename T> int load(uint32_t key_hash, T& value)
+    {
+        static_assert(etl::is_trivially_copyable_v<T>, "T must be trivially copyable");
+        return load_blob(key_hash, &value, sizeof(T));
+    }
+
+    /// @brief Delete a key from the store
+    /// @param key_hash 32-bit parameter key hash
+    /// @return 0 on success, negative error code on failure
+    int del(uint32_t key_hash);
+
+    // Non-copyable, non-movable
+    FlashKVStorage(const FlashKVStorage&) = delete;
+    FlashKVStorage& operator=(const FlashKVStorage&) = delete;
+
+  private:
+    FlashKVStorage();
+
+    /// @brief Convert a 32-bit hash to an 8-char hex string key
+    /// @param key_hash The hash value
+    /// @param buf Output buffer (must be at least 9 bytes)
+    static void hash_to_key(uint32_t key_hash, char* buf);
+
+    /// @brief Store a binary blob under the given key hash
+    int store_blob(uint32_t key_hash, const void* data, size_t size);
+
+    /// @brief Load a binary blob for the given key hash
+    int load_blob(uint32_t key_hash, void* data, size_t size);
+
+    /// @brief FlashDB lock callback
+    static void fdb_lock(fdb_db_t db);
+
+    /// @brief FlashDB unlock callback
+    static void fdb_unlock(fdb_db_t db);
+
+    static constexpr const char* kDBName = "flash_kv_storage"; ///< KVDB name for FlashDB init
+
+    struct fdb_kvdb kvdb_; ///< FlashDB KVDB instance
+    mutex_t kvdb_mutex_;   ///< Mutex for KVDB thread safety
+    bool initialized_;     ///< Whether KVDB has been initialized
+};
+
+} // namespace flash_kv_storage
+} // namespace cogip
+
+/// @}

--- a/lib/localization/Makefile
+++ b/lib/localization/Makefile
@@ -1,5 +1,1 @@
-ifneq (,$(filter localization_otos,$(USEMODULE)))
-  DIRS += localization_otos
-endif
-
 include $(RIOTBASE)/Makefile.base

--- a/lib/parameter/PB_ParameterCommands.proto
+++ b/lib/parameter/PB_ParameterCommands.proto
@@ -56,3 +56,16 @@ message PB_ParameterSetResponse
 	uint32 key_hash = 1;           ///< Parameter key hash
 	PB_ParameterStatus status = 2; ///< Operation status
 }
+
+/// @brief Reset parameter request
+message PB_ParameterResetRequest
+{
+	uint32 key_hash = 1; ///< Parameter key hash
+}
+
+/// @brief Reset parameter response
+message PB_ParameterResetResponse
+{
+	uint32 key_hash = 1;           ///< Parameter key hash
+	PB_ParameterStatus status = 2; ///< Operation status
+}

--- a/lib/parameter/include/parameter/ConversionPolicies.hpp
+++ b/lib/parameter/include/parameter/ConversionPolicies.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_parameter
+/// @{
+/// @file
+/// @brief      Unit conversion policies for protobuf interface
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#pragma once
+
+#include "etl/type_traits.h"
+
+namespace cogip {
+namespace parameter {
+
+/// @brief Speed unit conversion policy for protobuf interface
+/// Converts between user units (/s) and internal units (/period) at the protobuf boundary.
+/// Internal storage and C++ set()/get() remain in /period units.
+/// @tparam PeriodMs Control loop period in milliseconds (compile-time constant)
+template <int PeriodMs> struct SpeedConversion
+{
+    /// @brief Convert from user units (/s) to internal units (/period)
+    /// Called when receiving a value from protobuf (user configures in /s)
+    template <typename T> static void on_pb_read(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "SpeedConversion only supports float parameters");
+        value = value * static_cast<T>(PeriodMs) / static_cast<T>(1000);
+    }
+
+    /// @brief Convert from internal units (/period) to user units (/s)
+    /// Called when sending a value to protobuf (user sees /s)
+    template <typename T> static void on_pb_copy(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "SpeedConversion only supports float parameters");
+        value = value * static_cast<T>(1000) / static_cast<T>(PeriodMs);
+    }
+};
+
+/// @brief Acceleration unit conversion policy for protobuf interface
+/// Converts between user units (/s²) and internal units (/period²) at the protobuf boundary.
+/// Internal storage and C++ set()/get() remain in /period² units.
+/// @tparam PeriodMs Control loop period in milliseconds (compile-time constant)
+template <int PeriodMs> struct AccelerationConversion
+{
+    /// @brief Convert from user units (/s²) to internal units (/period²)
+    /// Called when receiving a value from protobuf (user configures in /s²)
+    template <typename T> static void on_pb_read(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "AccelerationConversion only supports float parameters");
+        value = value * (static_cast<T>(PeriodMs) * static_cast<T>(PeriodMs))
+                / (static_cast<T>(1000) * static_cast<T>(1000));
+    }
+
+    /// @brief Convert from internal units (/period²) to user units (/s²)
+    /// Called when sending a value to protobuf (user sees /s²)
+    template <typename T> static void on_pb_copy(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "AccelerationConversion only supports float parameters");
+        value = value * (static_cast<T>(1000) * static_cast<T>(1000))
+                / (static_cast<T>(PeriodMs) * static_cast<T>(PeriodMs));
+    }
+};
+
+} // namespace parameter
+} // namespace cogip
+
+/// @}

--- a/lib/parameter/include/parameter/ConversionPolicies.hpp
+++ b/lib/parameter/include/parameter/ConversionPolicies.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_parameter
+/// @{
+/// @file
+/// @brief      Unit conversion policies for protobuf interface
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#pragma once
+
+#include "etl/type_traits.h"
+
+namespace cogip {
+namespace parameter {
+
+/// @brief Speed unit conversion policy for protobuf interface
+/// Converts between user units (/s) and internal units (/period) at the protobuf boundary.
+/// Internal storage and C++ set()/get() remain in /period units.
+/// @tparam PeriodMs Control loop period in milliseconds (compile-time constant)
+template <int PeriodMs> struct SpeedConversion
+{
+    /// @brief Convert from user units (/s) to internal units (/period)
+    /// Called when receiving a value from protobuf (user configures in /s)
+    template <typename T> static void on_pb_read(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "SpeedConversion only supports float parameters");
+        value = value * static_cast<T>(PeriodMs) / static_cast<T>(1000);
+    }
+
+    /// @brief Convert from internal units (/period) to user units (/s)
+    /// Called when sending a value to protobuf (user sees /s)
+    template <typename T> static void on_pb_copy(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "SpeedConversion only supports float parameters");
+        value = value * static_cast<T>(1000) / static_cast<T>(PeriodMs);
+    }
+};
+
+/// @brief Acceleration unit conversion policy for protobuf interface
+/// Converts between user units (/s²) and internal units (/period²) at the protobuf boundary.
+/// Internal storage and C++ set()/get() remain in /period² units.
+/// @tparam PeriodMs Control loop period in milliseconds (compile-time constant)
+template <int PeriodMs> struct AccelerationConversion
+{
+    /// @brief Convert from user units (/s²) to internal units (/period²)
+    /// Called when receiving a value from protobuf (user configures in /s²)
+    template <typename T> static void on_pb_read(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "AccelerationConversion only supports float parameters");
+        value = value * (static_cast<T>(PeriodMs) * static_cast<T>(PeriodMs)) /
+                (static_cast<T>(1000) * static_cast<T>(1000));
+    }
+
+    /// @brief Convert from internal units (/period²) to user units (/s²)
+    /// Called when sending a value to protobuf (user sees /s²)
+    template <typename T> static void on_pb_copy(T& value)
+    {
+        static_assert(etl::is_same<T, float>::value,
+                      "AccelerationConversion only supports float parameters");
+        value = value * (static_cast<T>(1000) * static_cast<T>(1000)) /
+                (static_cast<T>(PeriodMs) * static_cast<T>(PeriodMs));
+    }
+};
+
+} // namespace parameter
+} // namespace cogip
+
+/// @}

--- a/lib/parameter/include/parameter/Parameter.hpp
+++ b/lib/parameter/include/parameter/Parameter.hpp
@@ -58,7 +58,7 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
 
   public:
     /// @brief Default constructor - initializes with invalid state
-    Parameter() : value_{}, valid_(false), changed_(true), mutex_(MUTEX_INIT)
+    Parameter() : value_{}, default_value_{}, valid_(false), changed_(true), mutex_(MUTEX_INIT)
     {
         mutex_init(&mutex_);
     }
@@ -66,7 +66,8 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
     /// @brief Constructor with initial value
     /// @param initial_value The initial value (will be processed through all policies)
     explicit Parameter(const T& initial_value)
-        : value_(initial_value), valid_(false), changed_(true), mutex_(MUTEX_INIT)
+        : value_(initial_value), default_value_(initial_value), valid_(false), changed_(true),
+          mutex_(MUTEX_INIT)
     {
         mutex_init(&mutex_);
         valid_ = combined_on_set<T, Policies...>(value_);
@@ -77,15 +78,21 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
     /// @return true if value was set successfully (all policies returned true)
     bool set(const T& value) override
     {
-        mutex_lock(&mutex_);
         T temp = value;
+
+        mutex_lock(&mutex_);
         valid_ = combined_on_set<T, Policies...>(temp);
         if (valid_) {
             value_ = temp;
             changed_ = true;
         }
+        const bool result = valid_;
         mutex_unlock(&mutex_);
-        return valid_;
+
+        if (result) {
+            combined_on_commit<T, Policies...>(temp);
+        }
+        return result;
     }
 
     /// @brief Check whether the value has changed since the last clear_changed().
@@ -102,6 +109,45 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
     {
         mutex_lock(&mutex_);
         changed_ = false;
+        mutex_unlock(&mutex_);
+    }
+
+    /// @brief Load value from persistent storage and re-validate
+    /// @return true if load succeeded (or no storage policy exists)
+    /// @note If flash contains a value that fails validation, the default is kept
+    ///       and load returns false. If no storage policy or no stored value,
+    ///       the default is kept and load returns true.
+    bool load() override
+    {
+        mutex_lock(&mutex_);
+        T temp = value_;
+        bool result = true;
+        if (combined_on_init<T, Policies...>(temp)) {
+            // A value was read from flash — validate it
+            if (combined_on_set<T, Policies...>(temp)) {
+                value_ = temp;
+                valid_ = true;
+            } else {
+                // Flash value rejected by validation, keep default
+                result = false;
+            }
+        }
+        // No storage policy or no stored value → keep default (success)
+        mutex_unlock(&mutex_);
+        return result;
+    }
+
+    /// @brief Erase persisted value and restore the compile-time default in memory
+    /// @note Fires the storage policy's on_clear hook (erases the flash entry),
+    ///       restores the value captured at construction, re-applies validation /
+    ///       commit policies and marks the parameter as changed.
+    void reset() override
+    {
+        mutex_lock(&mutex_);
+        combined_on_clear<Policies...>();
+        value_ = default_value_;
+        valid_ = combined_on_set<T, Policies...>(value_);
+        changed_ = true;
         mutex_unlock(&mutex_);
     }
 
@@ -214,6 +260,7 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
 
   private:
     T value_;               ///< Parameter value
+    const T default_value_; ///< Compile-time default captured at construction, used by reset()
     bool valid_;            ///< Validity flag
     mutable bool changed_;  ///< True if value was (re)set since the last clear_changed()
     mutable mutex_t mutex_; ///< Mutex for thread-safe access

--- a/lib/parameter/include/parameter/Parameter.hpp
+++ b/lib/parameter/include/parameter/Parameter.hpp
@@ -82,9 +82,35 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
         valid_ = combined_on_set<T, Policies...>(temp);
         if (valid_) {
             value_ = temp;
+            combined_on_commit<T, Policies...>(value_);
         }
         mutex_unlock(&mutex_);
         return valid_;
+    }
+
+    /// @brief Load value from persistent storage and re-validate
+    /// @return true if load succeeded (or no storage policy exists)
+    /// @note If flash contains a value that fails validation, the default is kept
+    ///       and load returns false. If no storage policy or no stored value,
+    ///       the default is kept and load returns true.
+    bool load() override
+    {
+        mutex_lock(&mutex_);
+        T temp = value_;
+        bool result = true;
+        if (combined_on_init<T, Policies...>(temp)) {
+            // A value was read from flash — validate it
+            if (combined_on_set<T, Policies...>(temp)) {
+                value_ = temp;
+                valid_ = true;
+            } else {
+                // Flash value rejected by validation, keep default
+                result = false;
+            }
+        }
+        // No storage policy or no stored value → keep default (success)
+        mutex_unlock(&mutex_);
+        return result;
     }
 
     /// @brief Get the current parameter value

--- a/lib/parameter/include/parameter/Parameter.hpp
+++ b/lib/parameter/include/parameter/Parameter.hpp
@@ -147,37 +147,36 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
     /// message.
     bool pb_copy(PB_ParameterValue& message) const override
     {
-        bool result = false;
-
         mutex_lock(&mutex_);
-        if constexpr (etl::is_same<T, float>::value) {
-            message.set_float_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, double>::value) {
-            message.set_double_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, int32_t>::value) {
-            message.set_int32_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, uint32_t>::value) {
-            message.set_uint32_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, int64_t>::value) {
-            message.set_int64_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, uint64_t>::value) {
-            message.set_uint64_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, bool>::value) {
-            message.set_bool_value(value_);
-            result = true;
-        } else {
-            // Unsupported type (should never happen due to Parameter static_assert)
-            result = false;
-        }
+        T copy = value_;
         mutex_unlock(&mutex_);
 
-        return result;
+        combined_on_pb_copy<T, Policies...>(copy);
+
+        if constexpr (etl::is_same<T, float>::value) {
+            message.set_float_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, double>::value) {
+            message.set_double_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, int32_t>::value) {
+            message.set_int32_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, uint32_t>::value) {
+            message.set_uint32_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, int64_t>::value) {
+            message.set_int64_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, uint64_t>::value) {
+            message.set_uint64_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, bool>::value) {
+            message.set_bool_value(copy);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /// @brief Convert parameter from protobuf PB_ParameterValue message
@@ -215,6 +214,7 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
         }
 
         if (success) {
+            combined_on_pb_read<T, Policies...>(new_value);
             return set(new_value); // Apply validation (set() is already mutex-protected)
         }
         return false;

--- a/lib/parameter/include/parameter/Parameter.hpp
+++ b/lib/parameter/include/parameter/Parameter.hpp
@@ -185,37 +185,36 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
     /// message.
     bool pb_copy(PB_ParameterValue& message) const override
     {
-        bool result = false;
-
         mutex_lock(&mutex_);
-        if constexpr (etl::is_same<T, float>::value) {
-            message.set_float_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, double>::value) {
-            message.set_double_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, int32_t>::value) {
-            message.set_int32_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, uint32_t>::value) {
-            message.set_uint32_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, int64_t>::value) {
-            message.set_int64_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, uint64_t>::value) {
-            message.set_uint64_value(value_);
-            result = true;
-        } else if constexpr (etl::is_same<T, bool>::value) {
-            message.set_bool_value(value_);
-            result = true;
-        } else {
-            // Unsupported type (should never happen due to Parameter static_assert)
-            result = false;
-        }
+        T copy = value_;
         mutex_unlock(&mutex_);
 
-        return result;
+        combined_on_pb_copy<T, Policies...>(copy);
+
+        if constexpr (etl::is_same<T, float>::value) {
+            message.set_float_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, double>::value) {
+            message.set_double_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, int32_t>::value) {
+            message.set_int32_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, uint32_t>::value) {
+            message.set_uint32_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, int64_t>::value) {
+            message.set_int64_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, uint64_t>::value) {
+            message.set_uint64_value(copy);
+            return true;
+        } else if constexpr (etl::is_same<T, bool>::value) {
+            message.set_bool_value(copy);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /// @brief Convert parameter from protobuf PB_ParameterValue message
@@ -253,6 +252,7 @@ template <typename T, typename... Policies> class Parameter : public ParameterIn
         }
 
         if (success) {
+            combined_on_pb_read<T, Policies...>(new_value);
             return set(new_value); // Apply validation (set() is already mutex-protected)
         }
         return false;

--- a/lib/parameter/include/parameter/ParameterInterface.hpp
+++ b/lib/parameter/include/parameter/ParameterInterface.hpp
@@ -39,6 +39,14 @@ class ParameterBase
     /// @brief Check if parameter holds valid value
     /// @return Status depending on the validation policy
     virtual bool isValid() const = 0;
+
+    /// @brief Load value from persistent storage (if a storage policy is present)
+    /// @return true if a value was successfully loaded and passed validation
+    /// @note Default implementation returns true (no storage means nothing to load).
+    virtual bool load()
+    {
+        return true;
+    }
 };
 
 /// @brief Typed interface for polymorphic parameter manipulation

--- a/lib/parameter/include/parameter/ParameterInterface.hpp
+++ b/lib/parameter/include/parameter/ParameterInterface.hpp
@@ -54,6 +54,21 @@ class ParameterBase
     /// Declared const because consumers typically keep read-only
     /// references to parameters they poll.
     virtual void clear_changed() const = 0;
+
+    /// @brief Load value from persistent storage (if a storage policy is present)
+    /// @return true if a value was successfully loaded and passed validation
+    /// @note Default implementation returns true (no storage means nothing to load).
+    virtual bool load()
+    {
+        return true;
+    }
+
+    /// @brief Erase persisted value and restore the compile-time default in memory
+    /// @note Clears the persisted storage (if a storage policy is present), then restores
+    ///       the initial value captured at construction, re-applies validation/commit
+    ///       policies and marks the parameter as changed so consumers pick it up.
+    ///       Default implementation is a no-op (parameters without a default cannot reset).
+    virtual void reset() {}
 };
 
 /// @brief Typed interface for polymorphic parameter manipulation

--- a/lib/parameter/include/parameter/PolicyTraits.hpp
+++ b/lib/parameter/include/parameter/PolicyTraits.hpp
@@ -112,7 +112,7 @@ struct has_on_clear<Policy, etl::void_t<decltype(Policy::on_clear())>> : etl::tr
 {
 };
 
-/// @brief Invoke on_clear on a single policy (erase from persistent storage)
+/// @brief Invoke on_clear on a single policy (erase persisted value)
 /// @tparam Policy The policy type
 template <typename Policy> void invoke_on_clear()
 {
@@ -192,7 +192,7 @@ template <typename T, typename... Policies> bool combined_on_init(T& value)
     return (detail::invoke_on_init<Policies, T>(value) || ...);
 }
 
-/// @brief Fire on_clear on all policies (erase from persistent storage, fire-and-forget)
+/// @brief Fire on_clear on all policies (erase persisted value, fire-and-forget)
 /// @tparam Policies The policy types to apply
 template <typename... Policies> void combined_on_clear()
 {

--- a/lib/parameter/include/parameter/PolicyTraits.hpp
+++ b/lib/parameter/include/parameter/PolicyTraits.hpp
@@ -33,6 +33,34 @@ struct has_on_set<Policy, T, etl::void_t<decltype(Policy::on_set(etl::declval<T&
 {
 };
 
+/// @brief Type trait to detect if Policy has on_commit(const T&) method
+/// @tparam Policy The policy type to check
+/// @tparam T The parameter value type
+template <typename Policy, typename T, typename = void> struct has_on_commit : etl::false_type
+{
+};
+
+/// @brief Specialization when Policy::on_commit(const T&) is valid
+template <typename Policy, typename T>
+struct has_on_commit<Policy, T, etl::void_t<decltype(Policy::on_commit(etl::declval<const T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Type trait to detect if Policy has on_init(T&) method
+/// @tparam Policy The policy type to check
+/// @tparam T The parameter value type
+template <typename Policy, typename T, typename = void> struct has_on_init : etl::false_type
+{
+};
+
+/// @brief Specialization when Policy::on_init(T&) is valid
+template <typename Policy, typename T>
+struct has_on_init<Policy, T, etl::void_t<decltype(Policy::on_init(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
 /// @brief Invoke on_set on a single policy
 /// @tparam Policy The policy type
 /// @tparam T The parameter value type
@@ -44,6 +72,90 @@ template <typename Policy, typename T> bool invoke_on_set(T& value)
         return Policy::on_set(value);
     } else {
         return true;
+    }
+}
+
+/// @brief Invoke on_commit on a single policy (post-validation persistence)
+/// @tparam Policy The policy type
+/// @tparam T The parameter value type
+/// @param value The validated value to persist
+template <typename Policy, typename T> void invoke_on_commit(const T& value)
+{
+    if constexpr (has_on_commit<Policy, T>::value) {
+        Policy::on_commit(value);
+    }
+}
+
+/// @brief Invoke on_init on a single policy (load from persistent storage)
+/// @tparam Policy The policy type
+/// @tparam T The parameter value type
+/// @param value Reference to value (overwritten if policy loads a stored value)
+/// @return true if value was loaded, false otherwise
+template <typename Policy, typename T> bool invoke_on_init(T& value)
+{
+    if constexpr (has_on_init<Policy, T>::value) {
+        return Policy::on_init(value);
+    } else {
+        return false;
+    }
+}
+
+/// @brief Type trait to detect if Policy has on_clear() method
+/// @tparam Policy The policy type to check
+template <typename Policy, typename = void> struct has_on_clear : etl::false_type
+{
+};
+
+/// @brief Specialization when Policy::on_clear() is valid
+template <typename Policy>
+struct has_on_clear<Policy, etl::void_t<decltype(Policy::on_clear())>> : etl::true_type
+{
+};
+
+/// @brief Invoke on_clear on a single policy (erase from persistent storage)
+/// @tparam Policy The policy type
+template <typename Policy> void invoke_on_clear()
+{
+    if constexpr (has_on_clear<Policy>::value) {
+        Policy::on_clear();
+    }
+}
+
+/// @brief Type trait to detect if Policy has on_pb_read(T&) method
+template <typename Policy, typename T, typename = void> struct has_on_pb_read : etl::false_type
+{
+};
+
+template <typename Policy, typename T>
+struct has_on_pb_read<Policy, T, etl::void_t<decltype(Policy::on_pb_read(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Type trait to detect if Policy has on_pb_copy(T&) method
+template <typename Policy, typename T, typename = void> struct has_on_pb_copy : etl::false_type
+{
+};
+
+template <typename Policy, typename T>
+struct has_on_pb_copy<Policy, T, etl::void_t<decltype(Policy::on_pb_copy(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Invoke on_pb_read on a single policy (convert user units to internal units)
+template <typename Policy, typename T> void invoke_on_pb_read(T& value)
+{
+    if constexpr (has_on_pb_read<Policy, T>::value) {
+        Policy::on_pb_read(value);
+    }
+}
+
+/// @brief Invoke on_pb_copy on a single policy (convert internal units to user units)
+template <typename Policy, typename T> void invoke_on_pb_copy(T& value)
+{
+    if constexpr (has_on_pb_copy<Policy, T>::value) {
+        Policy::on_pb_copy(value);
     }
 }
 
@@ -59,6 +171,50 @@ template <typename Policy, typename T> bool invoke_on_set(T& value)
 template <typename T, typename... Policies> bool combined_on_set(T& value)
 {
     return (detail::invoke_on_set<Policies, T>(value) && ...);
+}
+
+/// @brief Fire on_commit on all policies (post-validation, fire-and-forget)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value The validated value to persist
+template <typename T, typename... Policies> void combined_on_commit(const T& value)
+{
+    (detail::invoke_on_commit<Policies, T>(value), ...);
+}
+
+/// @brief Try on_init on all policies using OR semantics (first load wins)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (overwritten by first policy that loads successfully)
+/// @return true if any policy loaded a value
+template <typename T, typename... Policies> bool combined_on_init(T& value)
+{
+    return (detail::invoke_on_init<Policies, T>(value) || ...);
+}
+
+/// @brief Fire on_clear on all policies (erase from persistent storage, fire-and-forget)
+/// @tparam Policies The policy types to apply
+template <typename... Policies> void combined_on_clear()
+{
+    (detail::invoke_on_clear<Policies>(), ...);
+}
+
+/// @brief Apply on_pb_read from all policies (convert user units to internal units)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (modified by conversion policies)
+template <typename T, typename... Policies> void combined_on_pb_read(T& value)
+{
+    (detail::invoke_on_pb_read<Policies, T>(value), ...);
+}
+
+/// @brief Apply on_pb_copy from all policies (convert internal units to user units)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (modified by conversion policies)
+template <typename T, typename... Policies> void combined_on_pb_copy(T& value)
+{
+    (detail::invoke_on_pb_copy<Policies, T>(value), ...);
 }
 
 } // namespace parameter

--- a/lib/parameter/include/parameter/PolicyTraits.hpp
+++ b/lib/parameter/include/parameter/PolicyTraits.hpp
@@ -33,6 +33,35 @@ struct has_on_set<Policy, T, etl::void_t<decltype(Policy::on_set(etl::declval<T&
 {
 };
 
+/// @brief Type trait to detect if Policy has on_commit(const T&) method
+/// @tparam Policy The policy type to check
+/// @tparam T The parameter value type
+template <typename Policy, typename T, typename = void> struct has_on_commit : etl::false_type
+{
+};
+
+/// @brief Specialization when Policy::on_commit(const T&) is valid
+template <typename Policy, typename T>
+struct has_on_commit<Policy, T,
+                     etl::void_t<decltype(Policy::on_commit(etl::declval<const T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Type trait to detect if Policy has on_init(T&) method
+/// @tparam Policy The policy type to check
+/// @tparam T The parameter value type
+template <typename Policy, typename T, typename = void> struct has_on_init : etl::false_type
+{
+};
+
+/// @brief Specialization when Policy::on_init(T&) is valid
+template <typename Policy, typename T>
+struct has_on_init<Policy, T, etl::void_t<decltype(Policy::on_init(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
 /// @brief Invoke on_set on a single policy
 /// @tparam Policy The policy type
 /// @tparam T The parameter value type
@@ -44,6 +73,31 @@ template <typename Policy, typename T> bool invoke_on_set(T& value)
         return Policy::on_set(value);
     } else {
         return true;
+    }
+}
+
+/// @brief Invoke on_commit on a single policy (post-validation persistence)
+/// @tparam Policy The policy type
+/// @tparam T The parameter value type
+/// @param value The validated value to persist
+template <typename Policy, typename T> void invoke_on_commit(const T& value)
+{
+    if constexpr (has_on_commit<Policy, T>::value) {
+        Policy::on_commit(value);
+    }
+}
+
+/// @brief Invoke on_init on a single policy (load from persistent storage)
+/// @tparam Policy The policy type
+/// @tparam T The parameter value type
+/// @param value Reference to value (overwritten if policy loads a stored value)
+/// @return true if value was loaded, false otherwise
+template <typename Policy, typename T> bool invoke_on_init(T& value)
+{
+    if constexpr (has_on_init<Policy, T>::value) {
+        return Policy::on_init(value);
+    } else {
+        return false;
     }
 }
 
@@ -59,6 +113,25 @@ template <typename Policy, typename T> bool invoke_on_set(T& value)
 template <typename T, typename... Policies> bool combined_on_set(T& value)
 {
     return (detail::invoke_on_set<Policies, T>(value) && ...);
+}
+
+/// @brief Fire on_commit on all policies (post-validation, fire-and-forget)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value The validated value to persist
+template <typename T, typename... Policies> void combined_on_commit(const T& value)
+{
+    (detail::invoke_on_commit<Policies, T>(value), ...);
+}
+
+/// @brief Try on_init on all policies using OR semantics (first load wins)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (overwritten by first policy that loads successfully)
+/// @return true if any policy loaded a value
+template <typename T, typename... Policies> bool combined_on_init(T& value)
+{
+    return (detail::invoke_on_init<Policies, T>(value) || ...);
 }
 
 } // namespace parameter

--- a/lib/parameter/include/parameter/PolicyTraits.hpp
+++ b/lib/parameter/include/parameter/PolicyTraits.hpp
@@ -101,6 +101,44 @@ template <typename Policy, typename T> bool invoke_on_init(T& value)
     }
 }
 
+/// @brief Type trait to detect if Policy has on_pb_read(T&) method
+template <typename Policy, typename T, typename = void> struct has_on_pb_read : etl::false_type
+{
+};
+
+template <typename Policy, typename T>
+struct has_on_pb_read<Policy, T, etl::void_t<decltype(Policy::on_pb_read(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Type trait to detect if Policy has on_pb_copy(T&) method
+template <typename Policy, typename T, typename = void> struct has_on_pb_copy : etl::false_type
+{
+};
+
+template <typename Policy, typename T>
+struct has_on_pb_copy<Policy, T, etl::void_t<decltype(Policy::on_pb_copy(etl::declval<T&>()))>>
+    : etl::true_type
+{
+};
+
+/// @brief Invoke on_pb_read on a single policy (convert user units to internal units)
+template <typename Policy, typename T> void invoke_on_pb_read(T& value)
+{
+    if constexpr (has_on_pb_read<Policy, T>::value) {
+        Policy::on_pb_read(value);
+    }
+}
+
+/// @brief Invoke on_pb_copy on a single policy (convert internal units to user units)
+template <typename Policy, typename T> void invoke_on_pb_copy(T& value)
+{
+    if constexpr (has_on_pb_copy<Policy, T>::value) {
+        Policy::on_pb_copy(value);
+    }
+}
+
 } // namespace detail
 
 /// @brief Combine on_set from all policies using AND semantics
@@ -132,6 +170,24 @@ template <typename T, typename... Policies> void combined_on_commit(const T& val
 template <typename T, typename... Policies> bool combined_on_init(T& value)
 {
     return (detail::invoke_on_init<Policies, T>(value) || ...);
+}
+
+/// @brief Apply on_pb_read from all policies (convert user units to internal units)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (modified by conversion policies)
+template <typename T, typename... Policies> void combined_on_pb_read(T& value)
+{
+    (detail::invoke_on_pb_read<Policies, T>(value), ...);
+}
+
+/// @brief Apply on_pb_copy from all policies (convert internal units to user units)
+/// @tparam T The parameter value type
+/// @tparam Policies The policy types to apply
+/// @param value Reference to value (modified by conversion policies)
+template <typename T, typename... Policies> void combined_on_pb_copy(T& value)
+{
+    (detail::invoke_on_pb_copy<Policies, T>(value), ...);
 }
 
 } // namespace parameter

--- a/lib/parameter/include/parameter/StoragePolicies.hpp
+++ b/lib/parameter/include/parameter/StoragePolicies.hpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_parameter
+/// @{
+/// @file
+/// @brief      Storage policies for parameter flash persistence
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+#include "flash_kv_storage/FlashKVStorage.hpp"
+
+namespace cogip {
+namespace parameter {
+
+/// @brief Flash storage policy — persists parameter value to FlashDB KVDB
+/// @tparam KeyHash Compile-time 32-bit FNV-1a hash identifying this parameter
+///
+/// @details This policy provides three hooks:
+///   - `on_init(T& value)`: loads the stored value from flash (if present)
+///   - `on_commit(const T& value)`: saves the current value to flash after successful validation
+///   - `on_clear()`: erases the stored value from flash
+///
+/// Flash write failure does NOT reject an in-memory parameter update (on_commit is void).
+template <uint32_t KeyHash> struct WithFlashStorage
+{
+    /// @brief Load parameter value from flash storage
+    /// @tparam T The parameter value type
+    /// @param value Reference to value (overwritten if flash contains a valid entry)
+    /// @return true if a value was successfully loaded from flash
+    template <typename T> static bool on_init(T& value)
+    {
+        return flash_kv_storage::FlashKVStorage::instance().load(KeyHash, value) == 0;
+    }
+
+    /// @brief Save parameter value to flash storage
+    /// @tparam T The parameter value type
+    /// @param value The validated value to persist
+    template <typename T> static void on_commit(const T& value)
+    {
+        flash_kv_storage::FlashKVStorage::instance().store(KeyHash, value);
+    }
+
+    /// @brief Erase parameter value from flash storage
+    static void on_clear()
+    {
+        flash_kv_storage::FlashKVStorage::instance().del(KeyHash);
+    }
+};
+
+} // namespace parameter
+} // namespace cogip
+
+/// @}

--- a/lib/parameter/include/parameter/StoragePolicies.hpp
+++ b/lib/parameter/include/parameter/StoragePolicies.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @ingroup    lib_parameter
+/// @{
+/// @file
+/// @brief      Storage policies for parameter flash persistence
+/// @author     Mathis Lécrivain <lecrivain.mathis@gmail.com>
+
+#pragma once
+
+#include <cstdint>
+
+#include "flash_kv_storage/FlashKVStorage.hpp"
+
+namespace cogip {
+namespace parameter {
+
+/// @brief Flash storage policy — persists parameter value to FlashDB KVDB
+/// @tparam KeyHash Compile-time 32-bit FNV-1a hash identifying this parameter
+///
+/// @details This policy provides two hooks:
+///   - `on_init(T& value)`: loads the stored value from flash (if present)
+///   - `on_commit(const T& value)`: saves the current value to flash after successful validation
+///
+/// Flash write failure does NOT reject an in-memory parameter update (on_commit is void).
+template <uint32_t KeyHash> struct WithFlashStorage
+{
+    /// @brief Load parameter value from flash storage
+    /// @tparam T The parameter value type
+    /// @param value Reference to value (overwritten if flash contains a valid entry)
+    /// @return true if a value was successfully loaded from flash
+    template <typename T> static bool on_init(T& value)
+    {
+        return flash_kv_storage::FlashKVStorage::instance().load(KeyHash, value) == 0;
+    }
+
+    /// @brief Save parameter value to flash storage
+    /// @tparam T The parameter value type
+    /// @param value The validated value to persist
+    template <typename T> static void on_commit(const T& value)
+    {
+        flash_kv_storage::FlashKVStorage::instance().store(KeyHash, value);
+    }
+};
+
+} // namespace parameter
+} // namespace cogip
+
+/// @}

--- a/platforms/pf-common/Makefile.dep
+++ b/platforms/pf-common/Makefile.dep
@@ -1,2 +1,3 @@
 # Dependencies for pf-common module
 USEMODULE += canpb
+USEMODULE += flash_kv_storage

--- a/platforms/pf-common/include/pf_common/uuids.hpp
+++ b/platforms/pf-common/include/pf_common/uuids.hpp
@@ -75,6 +75,8 @@ constexpr canpb::uuid_t parameter_get_response_uuid = 0x3007;
 constexpr canpb::uuid_t telemetry_enable_uuid = 0x3008;
 constexpr canpb::uuid_t telemetry_disable_uuid = 0x3009;
 constexpr canpb::uuid_t telemetry_data_uuid = 0x300A;
+constexpr canpb::uuid_t parameter_reset_uuid = 0x300B;
+constexpr canpb::uuid_t parameter_reset_response_uuid = 0x300C;
 /** @} */
 
 /**

--- a/platforms/pf-common/platform_common.cpp
+++ b/platforms/pf-common/platform_common.cpp
@@ -16,6 +16,7 @@
 #include "ztimer.h"
 
 // Project includes
+#include "flash_kv_storage/FlashKVStorage.hpp"
 #include "pf_common/platform_common.hpp"
 #include "pf_common/uuids.hpp"
 
@@ -163,6 +164,14 @@ int pf_init(copilot_callback_t on_connect, copilot_callback_t on_disconnect,
     on_copilot_connected_callback = on_connect;
     on_copilot_disconnected_callback = on_disconnect;
     on_emergency_stop_callback = on_emergency_stop;
+
+    // Initialize flash key-value storage. On failure, FlashKVStorage no-ops
+    // every store/load/del, so we keep going to ensure CAN and the emergency
+    // stop handler get registered.
+    int flash_res = flash_kv_storage::FlashKVStorage::instance().init();
+    if (flash_res) {
+        LOG_ERROR("Flash KV storage initialization failed, error: %d\n", flash_res);
+    }
 
     // Initialize CAN with default filter
     int canpb_res = canpb.init(&canpb_filter);

--- a/platforms/pf-common/platform_common.cpp
+++ b/platforms/pf-common/platform_common.cpp
@@ -16,6 +16,7 @@
 #include "ztimer.h"
 
 // Project includes
+#include "flash_kv_storage/FlashKVStorage.hpp"
 #include "pf_common/platform_common.hpp"
 #include "pf_common/uuids.hpp"
 
@@ -113,6 +114,13 @@ int pf_init(copilot_callback_t on_connect, copilot_callback_t on_disconnect)
     // Store custom callbacks
     on_copilot_connected_callback = on_connect;
     on_copilot_disconnected_callback = on_disconnect;
+
+    // Initialize flash key-value storage
+    int flash_res = flash_kv_storage::FlashKVStorage::instance().init();
+    if (flash_res) {
+        LOG_ERROR("Flash KV storage initialization failed, error: %d\n", flash_res);
+        return flash_res;
+    }
 
     // Initialize CAN with default filter
     int canpb_res = canpb.init(&canpb_filter);

--- a/platforms/pf-robot-motion-control/include/motion_control.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control.hpp
@@ -17,18 +17,6 @@ namespace motion_control {
 /// rad/s²)
 #define X_SEC2_TO_X_PERIOD2(acc, period) ((acc) * (((period) * (period)) / (1000.0 * 1000.0)))
 
-typedef uint8_t pid_id_t;
-
-/// PID ids
-constexpr auto START_LINE = __LINE__;
-enum class PidEnum : pid_id_t {
-    LINEAR_POSE_PID = 1,
-    ANGULAR_POSE_PID = 2,
-    LINEAR_SPEED_PID = 3,
-    ANGULAR_SPEED_PID = 4
-};
-constexpr auto PID_COUNT = __LINE__ - START_LINE - 3;
-
 constexpr uint16_t motion_control_thread_period_ms = 20; ///< controller thread loop period
 
 /// Path instance for waypoint navigation

--- a/platforms/pf-robot-motion-control/include/motion_control.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control.hpp
@@ -11,70 +11,11 @@ namespace pf {
 
 namespace motion_control {
 
-/// Conversion macro from speed in x/s to x/period (eg. mm/s or rad/s)
-#define X_SEC_TO_X_PERIOD(speed, period) (((speed) * (period)) / 1000.0)
-/// Conversion macro from acceleration in x/s² to x/period² (eg. mm/s² or
-/// rad/s²)
-#define X_SEC2_TO_X_PERIOD2(acc, period) ((acc) * (((period) * (period)) / (1000.0 * 1000.0)))
-
-constexpr uint16_t motion_control_thread_period_ms = 20; ///< controller thread loop period
-
 /// Path instance for waypoint navigation
 inline cogip::path::Path motion_control_path;
 
 /// Throttle divider for QUADPID pose loop controllers (execute every N cycles)
 constexpr uint16_t quadpid_pose_controllers_throttle_divider = 1;
-
-/// @name Acceleration and speed profiles
-/// @{
-/// Maximum linear acceleration/deceleration
-/// (mm/<motion_control_thread_period_ms>²)
-constexpr float platform_max_acc_linear_mm_per_period2 =
-    X_SEC2_TO_X_PERIOD2(max_acc_mm_per_s2, motion_control_thread_period_ms);
-constexpr float platform_max_dec_linear_mm_per_period2 =
-    X_SEC2_TO_X_PERIOD2(max_dec_mm_per_s2, motion_control_thread_period_ms);
-
-/// Minimum/Maximum linear speed (mm/<motion_control_thread_period_ms>)
-constexpr float platform_min_speed_linear_mm_per_period =
-    X_SEC_TO_X_PERIOD(min_speed_mm_per_s, motion_control_thread_period_ms);
-constexpr float platform_max_speed_linear_mm_per_period =
-    X_SEC_TO_X_PERIOD(max_speed_mm_per_s, motion_control_thread_period_ms);
-
-/// Low angular speed (mm/<motion_control_thread_period_ms>)
-constexpr float platform_low_speed_linear_mm_per_period =
-    (platform_max_speed_linear_mm_per_period / 4);
-/// Normal angular speed (mm/<motion_control_thread_period_ms>)
-constexpr float platform_normal_speed_linear_mm_per_period =
-    (platform_max_speed_linear_mm_per_period / 2);
-
-/// Maximum angular acceleration/deceleration
-/// (rad/<motion_control_thread_period_ms>²)
-constexpr float platform_max_acc_angular_deg_per_period2 =
-    X_SEC2_TO_X_PERIOD2(max_acc_deg_per_s2, motion_control_thread_period_ms);
-constexpr float platform_max_dec_angular_deg_per_period2 =
-    X_SEC2_TO_X_PERIOD2(max_dec_deg_per_s2, motion_control_thread_period_ms);
-
-/// Minimum/Maximum angular speed (rad/<motion_control_thread_period_ms>)
-constexpr float platform_min_speed_angular_deg_per_period =
-    X_SEC_TO_X_PERIOD(min_speed_deg_per_s, motion_control_thread_period_ms);
-constexpr float platform_max_speed_angular_deg_per_period =
-    X_SEC_TO_X_PERIOD(max_speed_deg_per_s, motion_control_thread_period_ms);
-
-/// Low angular speed (rad/<motion_control_thread_period_ms>)
-constexpr float platform_low_speed_angular_deg_per_period =
-    (platform_max_speed_angular_deg_per_period / 4);
-/// Normal angular speed (deg/<motion_control_thread_period_ms>)
-constexpr float platform_normal_speed_angular_deg_per_period =
-    (platform_max_speed_angular_deg_per_period / 2);
-
-/// Linear anti-cloking setup
-constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_period =
-    (motion_control_thread_period_ms * platform_linear_anti_blocking_speed_threshold_mm_per_s) /
-    1000;
-constexpr double platform_linear_anti_blocking_error_threshold_mm_per_period =
-    (motion_control_thread_period_ms * platform_linear_anti_blocking_error_threshold_mm_per_s) /
-    1000;
-/// @}
 
 /// Handle brake signal to stop the robot
 void pf_handle_brake(const cogip::canpb::ReadBuffer& buffer);

--- a/platforms/pf-robot-motion-control/include/motion_control.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 // Project includes
-#include "app_conf.hpp"
+#include "motion_control_parameters.hpp"
 #include "path/Path.hpp"
 #include "platform.hpp"
 

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -17,6 +17,7 @@
 #include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
 #include "parameter/Parameter.hpp"
+#include "parameter/StoragePolicies.hpp"
 
 using namespace cogip::parameter;
 using cogip::utils::operator"" _key_hash;
@@ -76,44 +77,44 @@ inline Parameter<float, ReadOnly> qdec_left_polarity{default_qdec_left_polarity}
 inline Parameter<float, ReadOnly> qdec_right_polarity{default_qdec_right_polarity};
 
 /// Encoder parameters
-inline Parameter<float> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
+inline Parameter<float, WithFlashStorage<LEFT_WHEEL_DIAMETER_KEY>> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
+inline Parameter<float, WithFlashStorage<RIGHT_WHEEL_DIAMETER_KEY>> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
+inline Parameter<float, WithFlashStorage<ENCODER_WHEELS_DISTANCE_KEY>> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
 inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{default_encoder_wheels_resolution_pulses};
 
 // Linear pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_pose_pid_kp{default_linear_pose_pid_kp};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{default_linear_pose_pid_ki};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{default_linear_pose_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_POSE_PID_KP_KEY>> linear_pose_pid_kp{default_linear_pose_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_POSE_PID_KI_KEY>> linear_pose_pid_ki{default_linear_pose_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_POSE_PID_KD_KEY>> linear_pose_pid_kd{default_linear_pose_pid_kd};
 // Angular pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_pose_pid_kp{default_angular_pose_pid_kp};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{default_angular_pose_pid_ki};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{default_angular_pose_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_POSE_PID_KP_KEY>> angular_pose_pid_kp{default_angular_pose_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_POSE_PID_KI_KEY>> angular_pose_pid_ki{default_angular_pose_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_POSE_PID_KD_KEY>> angular_pose_pid_kd{default_angular_pose_pid_kd};
 // Linear speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_speed_pid_kp{default_linear_speed_pid_kp};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{default_linear_speed_pid_ki};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{default_linear_speed_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_SPEED_PID_KP_KEY>> linear_speed_pid_kp{default_linear_speed_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_SPEED_PID_KI_KEY>> linear_speed_pid_ki{default_linear_speed_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<LINEAR_SPEED_PID_KD_KEY>> linear_speed_pid_kd{default_linear_speed_pid_kd};
 // Angular speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_speed_pid_kp{default_angular_speed_pid_kp};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{default_angular_speed_pid_ki};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{default_angular_speed_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_SPEED_PID_KP_KEY>> angular_speed_pid_kp{default_angular_speed_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_SPEED_PID_KI_KEY>> angular_speed_pid_ki{default_angular_speed_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<ANGULAR_SPEED_PID_KD_KEY>> angular_speed_pid_kd{default_angular_speed_pid_kd};
 
 // Tracker linear pose PID
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_POSE_PID_KP_KEY>> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_POSE_PID_KI_KEY>> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_POSE_PID_KD_KEY>> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
 // Tracker angular pose PID
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KP_KEY>> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KI_KEY>> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KD_KEY>> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KP_KEY>> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KI_KEY>> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KD_KEY>> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KP_KEY>> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KI_KEY>> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
+inline Parameter<float, NonNegative, WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KD_KEY>> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
 
 // PID integral limits
 inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
@@ -134,6 +135,9 @@ inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{de
 namespace cogip {
 namespace pf {
 namespace motion_control {
+
+/// @brief Load all parameters from flash persistent storage
+void pf_load_parameters();
 
 /// @brief Handle parameter get request from canpb
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer);

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -4,32 +4,160 @@
 //// directory for more details.
 
 /// @file motion_control_parameters.hpp
-/// @brief Motion control parameter definitions and registry
+/// @brief Motion control parameter definitions, key hashes, and registry
 ///
-/// @note This file defines all parameter for motion control configuration.
+/// @note Parameter<> objects are declared here with their policies and flash
+///       storage keys. Default values come from the robot-specific app_conf.hpp.
 
 #pragma once
 
+#include <cstdint>
+
+#include "KeyHash.hpp"
+#include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
+#include "parameter/Parameter.hpp"
+
+using namespace cogip::parameter;
+using cogip::utils::operator"" _key_hash;
+
+// ============================================================================
+// Parameter key hashes
+// ============================================================================
+
+/// Odometry parameters keys
+constexpr uint32_t QDEC_LEFT_POLARITY_KEY = "qdec_left_polarity"_key_hash;
+constexpr uint32_t QDEC_RIGHT_POLARITY_KEY = "qdec_right_polarity"_key_hash;
+constexpr uint32_t LEFT_WHEEL_DIAMETER_KEY = "left_wheel_diameter_mm"_key_hash;
+constexpr uint32_t RIGHT_WHEEL_DIAMETER_KEY = "right_wheel_diameter_mm"_key_hash;
+constexpr uint32_t ENCODER_WHEELS_DISTANCE_KEY = "encoder_wheels_distance_mm"_key_hash;
+constexpr uint32_t ENCODER_WHEELS_RESOLUTION_KEY = "encoder_wheels_resolution_pulses"_key_hash;
+
+#ifdef ROBOT_HAS_OTOS
+// OTOS localization calibration scalars
+// ROBOT_HAS_OTOS is defined by the OTOS robot configuration and gates the registration of the
+// scalars in the CAN parameter registry so encoder-based robots are not polluted with keys they do
+// not own.
+constexpr uint32_t OTOS_LINEAR_SCALAR_KEY = "otos_linear_scalar"_key_hash;
+constexpr uint32_t OTOS_ANGULAR_SCALAR_KEY = "otos_angular_scalar"_key_hash;
+#endif
+
+// Linear pose PID
+constexpr uint32_t LINEAR_POSE_PID_KP_KEY = "linear_pose_pid_kp"_key_hash;
+constexpr uint32_t LINEAR_POSE_PID_KI_KEY = "linear_pose_pid_ki"_key_hash;
+constexpr uint32_t LINEAR_POSE_PID_KD_KEY = "linear_pose_pid_kd"_key_hash;
+// Angular pose PID
+constexpr uint32_t ANGULAR_POSE_PID_KP_KEY = "angular_pose_pid_kp"_key_hash;
+constexpr uint32_t ANGULAR_POSE_PID_KI_KEY = "angular_pose_pid_ki"_key_hash;
+constexpr uint32_t ANGULAR_POSE_PID_KD_KEY = "angular_pose_pid_kd"_key_hash;
+// Linear speed PID
+constexpr uint32_t LINEAR_SPEED_PID_KP_KEY = "linear_speed_pid_kp"_key_hash;
+constexpr uint32_t LINEAR_SPEED_PID_KI_KEY = "linear_speed_pid_ki"_key_hash;
+constexpr uint32_t LINEAR_SPEED_PID_KD_KEY = "linear_speed_pid_kd"_key_hash;
+// Angular speed PID
+constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
+constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
+constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
+
+// Tracker linear pose PID
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KP_KEY = "tracker_linear_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KI_KEY = "tracker_linear_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KD_KEY = "tracker_linear_pose_pid_kd"_key_hash;
+// Tracker angular pose PID
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KP_KEY = "tracker_angular_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KI_KEY = "tracker_angular_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KD_KEY = "tracker_angular_pose_pid_kd"_key_hash;
+// Tracker linear speed PID
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KP_KEY = "tracker_linear_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KI_KEY = "tracker_linear_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_kd"_key_hash;
+// Tracker angular speed PID
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
+
+// ============================================================================
+// Parameter objects (default values from robot-specific app_conf.hpp)
+// ============================================================================
+// clang-format off
+/// Quadrature decoding polarity
+inline Parameter<float, ReadOnly> qdec_left_polarity{default_qdec_left_polarity};
+inline Parameter<float, ReadOnly> qdec_right_polarity{default_qdec_right_polarity};
+
+/// Encoder parameters
+inline Parameter<float> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
+inline Parameter<float> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
+inline Parameter<float> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
+inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{default_encoder_wheels_resolution_pulses};
+
+// OTOS localization calibration scalars
+// Range [0.872, 1.127] is the valid domain of the OTOS linear/angular
+// calibration scalars. WithBounds rejects out-of-range flash entries
+// or bus writes instead of silently normalizing them, so calibration
+// mistakes surface as an invalid parameter.
+#ifdef ROBOT_HAS_OTOS
+inline Parameter<float, WithBounds<0.872f, 1.127f>, WithFlashStorage<OTOS_LINEAR_SCALAR_KEY>> otos_linear_scalar{default_otos_linear_scalar};
+inline Parameter<float, WithBounds<0.872f, 1.127f>, WithFlashStorage<OTOS_ANGULAR_SCALAR_KEY>> otos_angular_scalar{default_otos_angular_scalar};
+#endif
+
+// Linear pose PID (QUADPID chain)
+inline Parameter<float, NonNegative> linear_pose_pid_kp{default_linear_pose_pid_kp};
+inline Parameter<float, NonNegative> linear_pose_pid_ki{default_linear_pose_pid_ki};
+inline Parameter<float, NonNegative> linear_pose_pid_kd{default_linear_pose_pid_kd};
+// Angular pose PID (QUADPID chain)
+inline Parameter<float, NonNegative> angular_pose_pid_kp{default_angular_pose_pid_kp};
+inline Parameter<float, NonNegative> angular_pose_pid_ki{default_angular_pose_pid_ki};
+inline Parameter<float, NonNegative> angular_pose_pid_kd{default_angular_pose_pid_kd};
+// Linear speed PID (QUADPID chain)
+inline Parameter<float, NonNegative> linear_speed_pid_kp{default_linear_speed_pid_kp};
+inline Parameter<float, NonNegative> linear_speed_pid_ki{default_linear_speed_pid_ki};
+inline Parameter<float, NonNegative> linear_speed_pid_kd{default_linear_speed_pid_kd};
+// Angular speed PID (QUADPID chain)
+inline Parameter<float, NonNegative> angular_speed_pid_kp{default_angular_speed_pid_kp};
+inline Parameter<float, NonNegative> angular_speed_pid_ki{default_angular_speed_pid_ki};
+inline Parameter<float, NonNegative> angular_speed_pid_kd{default_angular_speed_pid_kd};
+
+// Tracker linear pose PID
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
+// Tracker angular pose PID
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
+// Tracker linear speed PID
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
+// Tracker angular speed PID
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
+
+// PID integral limits
+inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{default_angular_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{default_linear_speed_pid_integral_limit};
+inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{default_angular_speed_pid_integral_limit};
+
+// Tracker PID integral limits
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{default_tracker_linear_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+// clang-format on
+// ============================================================================
+// Parameter registry handlers (canpb)
+// ============================================================================
 
 namespace cogip {
 namespace pf {
 namespace motion_control {
 
 /// @brief Handle parameter get request from canpb
-///
-/// @note Processes a parameter get request received via CAN bus, retrieves the requested
-///       parameter value from the registry, and sends back a response.
-///
-/// @param[in] buffer CAN protocol buffer containing the serialized parameter get request
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer);
 
 /// @brief Handle parameter set request from CAN bus
-///
-/// @note Processes a parameter set request received via CAN bus, updates the parameter
-///       value in the registry, and sends back a response with the operation status.
-///
-/// @param[in] buffer CAN protocol buffer containing the serialized parameter set request
 void pf_handle_parameter_set(cogip::canpb::ReadBuffer& buffer);
 
 } // namespace motion_control

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -16,10 +16,10 @@
 #include "KeyHash.hpp"
 #include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
+#include "parameter/ConversionPolicies.hpp"
 #include "parameter/Parameter.hpp"
 #include "parameter/StoragePolicies.hpp"
 
-using namespace cogip::parameter;
 using cogip::utils::operator"" _key_hash;
 
 // ============================================================================
@@ -60,6 +60,21 @@ constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
 constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
 constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
 
+// Pose straight filter thresholds
+constexpr uint32_t LINEAR_THRESHOLD_KEY = "linear_threshold"_key_hash;
+constexpr uint32_t ANGULAR_THRESHOLD_KEY = "angular_threshold"_key_hash;
+constexpr uint32_t ANGULAR_INTERMEDIATE_THRESHOLD_KEY = "angular_intermediate_threshold"_key_hash;
+
+// Speed and acceleration limits
+constexpr uint32_t MIN_SPEED_LINEAR_KEY = "min_speed_linear"_key_hash;
+constexpr uint32_t MAX_SPEED_LINEAR_KEY = "max_speed_linear"_key_hash;
+constexpr uint32_t MAX_ACC_LINEAR_KEY = "max_acc_linear"_key_hash;
+constexpr uint32_t MAX_DEC_LINEAR_KEY = "max_dec_linear"_key_hash;
+constexpr uint32_t MIN_SPEED_ANGULAR_KEY = "min_speed_angular"_key_hash;
+constexpr uint32_t MAX_SPEED_ANGULAR_KEY = "max_speed_angular"_key_hash;
+constexpr uint32_t MAX_ACC_ANGULAR_KEY = "max_acc_angular"_key_hash;
+constexpr uint32_t MAX_DEC_ANGULAR_KEY = "max_dec_angular"_key_hash;
+
 // Tracker linear pose PID
 constexpr uint32_t TRACKER_LINEAR_POSE_PID_KP_KEY = "tracker_linear_pose_pid_kp"_key_hash;
 constexpr uint32_t TRACKER_LINEAR_POSE_PID_KI_KEY = "tracker_linear_pose_pid_ki"_key_hash;
@@ -76,6 +91,63 @@ constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_k
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
+
+// ============================================================================
+// Unit conversion macros and control loop period
+// ============================================================================
+
+/// Conversion macro from speed in x/s to x/period (eg. mm/s or rad/s)
+#define X_SEC_TO_X_PERIOD(speed, period) (((speed) * (period)) / 1000.0)
+/// Conversion macro from acceleration in x/s² to x/period² (eg. mm/s² or rad/s²)
+#define X_SEC2_TO_X_PERIOD2(acc, period) ((acc) * (((period) * (period)) / (1000.0 * 1000.0)))
+
+namespace cogip {
+namespace pf {
+namespace motion_control {
+
+constexpr uint16_t motion_control_thread_period_ms = 20; ///< controller thread loop period
+
+/// @name Platform speed/acceleration constexpr (per-period units, derived from app_conf.hpp)
+/// @{
+constexpr float platform_max_acc_linear_mm_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_acc_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_linear_mm_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_dec_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_min_speed_linear_mm_per_period =
+    X_SEC_TO_X_PERIOD(min_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_linear_mm_per_period =
+    X_SEC_TO_X_PERIOD(max_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_low_speed_linear_mm_per_period =
+    (platform_max_speed_linear_mm_per_period / 4);
+constexpr float platform_normal_speed_linear_mm_per_period =
+    (platform_max_speed_linear_mm_per_period / 2);
+
+constexpr float platform_max_acc_angular_deg_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_acc_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_angular_deg_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_dec_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_min_speed_angular_deg_per_period =
+    X_SEC_TO_X_PERIOD(min_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_angular_deg_per_period =
+    X_SEC_TO_X_PERIOD(max_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_low_speed_angular_deg_per_period =
+    (platform_max_speed_angular_deg_per_period / 4);
+constexpr float platform_normal_speed_angular_deg_per_period =
+    (platform_max_speed_angular_deg_per_period / 2);
+
+constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_period =
+    (motion_control_thread_period_ms * platform_linear_anti_blocking_speed_threshold_mm_per_s) /
+    1000;
+constexpr double platform_linear_anti_blocking_error_threshold_mm_per_period =
+    (motion_control_thread_period_ms * platform_linear_anti_blocking_error_threshold_mm_per_s) /
+    1000;
+/// @}
+
+} // namespace motion_control
+} // namespace pf
+} // namespace cogip
+
+using namespace cogip::pf::motion_control;
 
 // ============================================================================
 // Parameter objects (default values from robot-specific app_conf.hpp)
@@ -142,10 +214,27 @@ inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> linear_
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> angular_speed_pid_integral_limit{default_angular_speed_pid_integral_limit};
 
 // Tracker PID integral limits
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{default_tracker_linear_pose_pid_integral_limit};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_linear_pose_pid_integral_limit{default_tracker_linear_pose_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+
+// Pose straight filter thresholds (absolute units: mm, deg)
+inline cogip::parameter::Parameter<float, cogip::parameter::Clamp<1, 10>, cogip::parameter::WithFlashStorage<LINEAR_THRESHOLD_KEY>> param_linear_threshold{linear_threshold};
+inline cogip::parameter::Parameter<float, cogip::parameter::Clamp<1, 5>, cogip::parameter::WithFlashStorage<ANGULAR_THRESHOLD_KEY>> param_angular_threshold{angular_threshold};
+inline cogip::parameter::Parameter<float, cogip::parameter::Clamp<1, 5>, cogip::parameter::WithFlashStorage<ANGULAR_INTERMEDIATE_THRESHOLD_KEY>> param_angular_intermediate_threshold{angular_intermediate_threshold};
+
+// Speed limits (internal: /period, protobuf: /s)
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::SpeedConversion<motion_control_thread_period_ms>> param_min_speed_linear{platform_min_speed_linear_mm_per_period};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::SpeedConversion<motion_control_thread_period_ms>> param_max_speed_linear{platform_max_speed_linear_mm_per_period};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::SpeedConversion<motion_control_thread_period_ms>> param_min_speed_angular{platform_min_speed_angular_deg_per_period};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::SpeedConversion<motion_control_thread_period_ms>> param_max_speed_angular{platform_max_speed_angular_deg_per_period};
+
+// Acceleration/deceleration limits (internal: /period², protobuf: /s²)
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::AccelerationConversion<motion_control_thread_period_ms>> param_max_acc_linear{platform_max_acc_linear_mm_per_period2};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::AccelerationConversion<motion_control_thread_period_ms>> param_max_dec_linear{platform_max_dec_linear_mm_per_period2};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::AccelerationConversion<motion_control_thread_period_ms>> param_max_acc_angular{platform_max_acc_angular_deg_per_period2};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::AccelerationConversion<motion_control_thread_period_ms>> param_max_dec_angular{platform_max_dec_angular_deg_per_period2};
 // clang-format on
 // ============================================================================
 // Parameter registry handlers (canpb)

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -253,6 +253,10 @@ void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer);
 /// @brief Handle parameter set request from CAN bus
 void pf_handle_parameter_set(cogip::canpb::ReadBuffer& buffer);
 
+/// @brief Handle parameter reset request from CAN bus
+/// @note Erases the persisted value and restores the compile-time default
+void pf_handle_parameter_reset(cogip::canpb::ReadBuffer& buffer);
+
 } // namespace motion_control
 } // namespace pf
 } // namespace cogip

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -17,6 +17,7 @@
 #include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
 #include "parameter/Parameter.hpp"
+#include "parameter/StoragePolicies.hpp"
 
 using namespace cogip::parameter;
 using cogip::utils::operator"" _key_hash;
@@ -81,14 +82,14 @@ constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid
 // ============================================================================
 // clang-format off
 /// Quadrature decoding polarity
-inline Parameter<float, ReadOnly> qdec_left_polarity{default_qdec_left_polarity};
-inline Parameter<float, ReadOnly> qdec_right_polarity{default_qdec_right_polarity};
+inline cogip::parameter::Parameter<float, cogip::parameter::ReadOnly> qdec_left_polarity{default_qdec_left_polarity};
+inline cogip::parameter::Parameter<float, cogip::parameter::ReadOnly> qdec_right_polarity{default_qdec_right_polarity};
 
 /// Encoder parameters
-inline Parameter<float> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
-inline Parameter<float> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
-inline Parameter<float> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
-inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{default_encoder_wheels_resolution_pulses};
+inline cogip::parameter::Parameter<float, cogip::parameter::WithFlashStorage<LEFT_WHEEL_DIAMETER_KEY>> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
+inline cogip::parameter::Parameter<float, cogip::parameter::WithFlashStorage<RIGHT_WHEEL_DIAMETER_KEY>> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
+inline cogip::parameter::Parameter<float, cogip::parameter::WithFlashStorage<ENCODER_WHEELS_DISTANCE_KEY>> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
+inline cogip::parameter::Parameter<float, cogip::parameter::ReadOnly> encoder_wheels_resolution_pulses{default_encoder_wheels_resolution_pulses};
 
 // OTOS localization calibration scalars
 // Range [0.872, 1.127] is the valid domain of the OTOS linear/angular
@@ -96,49 +97,49 @@ inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{default_encod
 // or bus writes instead of silently normalizing them, so calibration
 // mistakes surface as an invalid parameter.
 #ifdef ROBOT_HAS_OTOS
-inline Parameter<float, WithBounds<0.872f, 1.127f>, WithFlashStorage<OTOS_LINEAR_SCALAR_KEY>> otos_linear_scalar{default_otos_linear_scalar};
-inline Parameter<float, WithBounds<0.872f, 1.127f>, WithFlashStorage<OTOS_ANGULAR_SCALAR_KEY>> otos_angular_scalar{default_otos_angular_scalar};
+inline cogip::parameter::Parameter<float, cogip::parameter::WithBounds<0.872f, 1.127f>, cogip::parameter::WithFlashStorage<OTOS_LINEAR_SCALAR_KEY>> otos_linear_scalar{default_otos_linear_scalar};
+inline cogip::parameter::Parameter<float, cogip::parameter::WithBounds<0.872f, 1.127f>, cogip::parameter::WithFlashStorage<OTOS_ANGULAR_SCALAR_KEY>> otos_angular_scalar{default_otos_angular_scalar};
 #endif
 
 // Linear pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_pose_pid_kp{default_linear_pose_pid_kp};
-inline Parameter<float, NonNegative> linear_pose_pid_ki{default_linear_pose_pid_ki};
-inline Parameter<float, NonNegative> linear_pose_pid_kd{default_linear_pose_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_POSE_PID_KP_KEY>> linear_pose_pid_kp{default_linear_pose_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_POSE_PID_KI_KEY>> linear_pose_pid_ki{default_linear_pose_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_POSE_PID_KD_KEY>> linear_pose_pid_kd{default_linear_pose_pid_kd};
 // Angular pose PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_pose_pid_kp{default_angular_pose_pid_kp};
-inline Parameter<float, NonNegative> angular_pose_pid_ki{default_angular_pose_pid_ki};
-inline Parameter<float, NonNegative> angular_pose_pid_kd{default_angular_pose_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_POSE_PID_KP_KEY>> angular_pose_pid_kp{default_angular_pose_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_POSE_PID_KI_KEY>> angular_pose_pid_ki{default_angular_pose_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_POSE_PID_KD_KEY>> angular_pose_pid_kd{default_angular_pose_pid_kd};
 // Linear speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> linear_speed_pid_kp{default_linear_speed_pid_kp};
-inline Parameter<float, NonNegative> linear_speed_pid_ki{default_linear_speed_pid_ki};
-inline Parameter<float, NonNegative> linear_speed_pid_kd{default_linear_speed_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_SPEED_PID_KP_KEY>> linear_speed_pid_kp{default_linear_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_SPEED_PID_KI_KEY>> linear_speed_pid_ki{default_linear_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<LINEAR_SPEED_PID_KD_KEY>> linear_speed_pid_kd{default_linear_speed_pid_kd};
 // Angular speed PID (QUADPID chain)
-inline Parameter<float, NonNegative> angular_speed_pid_kp{default_angular_speed_pid_kp};
-inline Parameter<float, NonNegative> angular_speed_pid_ki{default_angular_speed_pid_ki};
-inline Parameter<float, NonNegative> angular_speed_pid_kd{default_angular_speed_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_SPEED_PID_KP_KEY>> angular_speed_pid_kp{default_angular_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_SPEED_PID_KI_KEY>> angular_speed_pid_ki{default_angular_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<ANGULAR_SPEED_PID_KD_KEY>> angular_speed_pid_kd{default_angular_speed_pid_kd};
 
 // Tracker linear pose PID
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
-inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_POSE_PID_KP_KEY>> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_POSE_PID_KI_KEY>> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_POSE_PID_KD_KEY>> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
 // Tracker angular pose PID
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
-inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KP_KEY>> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KI_KEY>> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_POSE_PID_KD_KEY>> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
 // Tracker linear speed PID
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
-inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KP_KEY>> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KI_KEY>> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_LINEAR_SPEED_PID_KD_KEY>> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
 // Tracker angular speed PID
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
-inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KP_KEY>> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KI_KEY>> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KD_KEY>> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
 
 // PID integral limits
-inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
-inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{default_angular_pose_pid_integral_limit};
-inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{default_linear_speed_pid_integral_limit};
-inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{default_angular_speed_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> angular_pose_pid_integral_limit{default_angular_pose_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> linear_speed_pid_integral_limit{default_linear_speed_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> angular_speed_pid_integral_limit{default_angular_speed_pid_integral_limit};
 
 // Tracker PID integral limits
 inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{default_tracker_linear_pose_pid_integral_limit};
@@ -153,6 +154,9 @@ inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{de
 namespace cogip {
 namespace pf {
 namespace motion_control {
+
+/// @brief Load all parameters from flash persistent storage
+void pf_load_parameters();
 
 /// @brief Handle parameter get request from canpb
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer);

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -16,6 +16,7 @@
 #include "KeyHash.hpp"
 #include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
+#include "parameter/ConversionPolicies.hpp"
 #include "parameter/Parameter.hpp"
 #include "parameter/StoragePolicies.hpp"
 
@@ -51,6 +52,21 @@ constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
 constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
 constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
 
+// Pose straight filter thresholds
+constexpr uint32_t LINEAR_THRESHOLD_KEY = "linear_threshold"_key_hash;
+constexpr uint32_t ANGULAR_THRESHOLD_KEY = "angular_threshold"_key_hash;
+constexpr uint32_t ANGULAR_INTERMEDIATE_THRESHOLD_KEY = "angular_intermediate_threshold"_key_hash;
+
+// Speed and acceleration limits
+constexpr uint32_t MIN_SPEED_LINEAR_KEY = "min_speed_linear"_key_hash;
+constexpr uint32_t MAX_SPEED_LINEAR_KEY = "max_speed_linear"_key_hash;
+constexpr uint32_t MAX_ACC_LINEAR_KEY = "max_acc_linear"_key_hash;
+constexpr uint32_t MAX_DEC_LINEAR_KEY = "max_dec_linear"_key_hash;
+constexpr uint32_t MIN_SPEED_ANGULAR_KEY = "min_speed_angular"_key_hash;
+constexpr uint32_t MAX_SPEED_ANGULAR_KEY = "max_speed_angular"_key_hash;
+constexpr uint32_t MAX_ACC_ANGULAR_KEY = "max_acc_angular"_key_hash;
+constexpr uint32_t MAX_DEC_ANGULAR_KEY = "max_dec_angular"_key_hash;
+
 // Tracker linear pose PID
 constexpr uint32_t TRACKER_LINEAR_POSE_PID_KP_KEY = "tracker_linear_pose_pid_kp"_key_hash;
 constexpr uint32_t TRACKER_LINEAR_POSE_PID_KI_KEY = "tracker_linear_pose_pid_ki"_key_hash;
@@ -67,6 +83,63 @@ constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_k
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
+
+// ============================================================================
+// Unit conversion macros and control loop period
+// ============================================================================
+
+/// Conversion macro from speed in x/s to x/period (eg. mm/s or rad/s)
+#define X_SEC_TO_X_PERIOD(speed, period) (((speed) * (period)) / 1000.0)
+/// Conversion macro from acceleration in x/s² to x/period² (eg. mm/s² or rad/s²)
+#define X_SEC2_TO_X_PERIOD2(acc, period) ((acc) * (((period) * (period)) / (1000.0 * 1000.0)))
+
+namespace cogip {
+namespace pf {
+namespace motion_control {
+
+constexpr uint16_t motion_control_thread_period_ms = 20; ///< controller thread loop period
+
+/// @name Platform speed/acceleration constexpr (per-period units, derived from app_conf.hpp)
+/// @{
+constexpr float platform_max_acc_linear_mm_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_acc_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_linear_mm_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_dec_mm_per_s2, motion_control_thread_period_ms);
+constexpr float platform_min_speed_linear_mm_per_period =
+    X_SEC_TO_X_PERIOD(min_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_linear_mm_per_period =
+    X_SEC_TO_X_PERIOD(max_speed_mm_per_s, motion_control_thread_period_ms);
+constexpr float platform_low_speed_linear_mm_per_period =
+    (platform_max_speed_linear_mm_per_period / 4);
+constexpr float platform_normal_speed_linear_mm_per_period =
+    (platform_max_speed_linear_mm_per_period / 2);
+
+constexpr float platform_max_acc_angular_deg_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_acc_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_max_dec_angular_deg_per_period2 =
+    X_SEC2_TO_X_PERIOD2(max_dec_deg_per_s2, motion_control_thread_period_ms);
+constexpr float platform_min_speed_angular_deg_per_period =
+    X_SEC_TO_X_PERIOD(min_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_max_speed_angular_deg_per_period =
+    X_SEC_TO_X_PERIOD(max_speed_deg_per_s, motion_control_thread_period_ms);
+constexpr float platform_low_speed_angular_deg_per_period =
+    (platform_max_speed_angular_deg_per_period / 4);
+constexpr float platform_normal_speed_angular_deg_per_period =
+    (platform_max_speed_angular_deg_per_period / 2);
+
+constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_period =
+    (motion_control_thread_period_ms * platform_linear_anti_blocking_speed_threshold_mm_per_s) /
+    1000;
+constexpr double platform_linear_anti_blocking_error_threshold_mm_per_period =
+    (motion_control_thread_period_ms * platform_linear_anti_blocking_error_threshold_mm_per_s) /
+    1000;
+/// @}
+
+} // namespace motion_control
+} // namespace pf
+} // namespace cogip
+
+using namespace cogip::pf::motion_control;
 
 // ============================================================================
 // Parameter objects (default values from robot-specific app_conf.hpp)
@@ -127,6 +200,23 @@ inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{defa
 inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
 inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
 inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+
+// Pose straight filter thresholds (absolute units: mm, deg)
+inline Parameter<float, Clamp<1, 10>, WithFlashStorage<LINEAR_THRESHOLD_KEY>> param_linear_threshold{linear_threshold};
+inline Parameter<float, Clamp<1, 5>, WithFlashStorage<ANGULAR_THRESHOLD_KEY>> param_angular_threshold{angular_threshold};
+inline Parameter<float, Clamp<1, 5>, WithFlashStorage<ANGULAR_INTERMEDIATE_THRESHOLD_KEY>> param_angular_intermediate_threshold{angular_intermediate_threshold};
+
+// Speed limits (internal: /period, protobuf: /s)
+inline Parameter<float, NonNegative, SpeedConversion<motion_control_thread_period_ms>> param_min_speed_linear{platform_min_speed_linear_mm_per_period};
+inline Parameter<float, NonNegative, SpeedConversion<motion_control_thread_period_ms>> param_max_speed_linear{platform_max_speed_linear_mm_per_period};
+inline Parameter<float, NonNegative, SpeedConversion<motion_control_thread_period_ms>> param_min_speed_angular{platform_min_speed_angular_deg_per_period};
+inline Parameter<float, NonNegative, SpeedConversion<motion_control_thread_period_ms>> param_max_speed_angular{platform_max_speed_angular_deg_per_period};
+
+// Acceleration/deceleration limits (internal: /period², protobuf: /s²)
+inline Parameter<float, NonNegative, AccelerationConversion<motion_control_thread_period_ms>> param_max_acc_linear{platform_max_acc_linear_mm_per_period2};
+inline Parameter<float, NonNegative, AccelerationConversion<motion_control_thread_period_ms>> param_max_dec_linear{platform_max_dec_linear_mm_per_period2};
+inline Parameter<float, NonNegative, AccelerationConversion<motion_control_thread_period_ms>> param_max_acc_angular{platform_max_acc_angular_deg_per_period2};
+inline Parameter<float, NonNegative, AccelerationConversion<motion_control_thread_period_ms>> param_max_dec_angular{platform_max_dec_angular_deg_per_period2};
 // clang-format on
 // ============================================================================
 // Parameter registry handlers (canpb)

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -4,32 +4,141 @@
 //// directory for more details.
 
 /// @file motion_control_parameters.hpp
-/// @brief Motion control parameter definitions and registry
+/// @brief Motion control parameter definitions, key hashes, and registry
 ///
-/// @note This file defines all parameter for motion control configuration.
+/// @note Parameter<> objects are declared here with their policies and flash
+///       storage keys. Default values come from the robot-specific app_conf.hpp.
 
 #pragma once
 
+#include <cstdint>
+
+#include "KeyHash.hpp"
+#include "app_conf.hpp"
 #include "canpb/ReadBuffer.hpp"
+#include "parameter/Parameter.hpp"
+
+using namespace cogip::parameter;
+using cogip::utils::operator"" _key_hash;
+
+// ============================================================================
+// Parameter key hashes
+// ============================================================================
+
+/// Odometry parameters keys
+constexpr uint32_t QDEC_LEFT_POLARITY_KEY = "qdec_left_polarity"_key_hash;
+constexpr uint32_t QDEC_RIGHT_POLARITY_KEY = "qdec_right_polarity"_key_hash;
+constexpr uint32_t LEFT_WHEEL_DIAMETER_KEY = "left_wheel_diameter_mm"_key_hash;
+constexpr uint32_t RIGHT_WHEEL_DIAMETER_KEY = "right_wheel_diameter_mm"_key_hash;
+constexpr uint32_t ENCODER_WHEELS_DISTANCE_KEY = "encoder_wheels_distance_mm"_key_hash;
+constexpr uint32_t ENCODER_WHEELS_RESOLUTION_KEY = "encoder_wheels_resolution_pulses"_key_hash;
+
+// Linear pose PID
+constexpr uint32_t LINEAR_POSE_PID_KP_KEY = "linear_pose_pid_kp"_key_hash;
+constexpr uint32_t LINEAR_POSE_PID_KI_KEY = "linear_pose_pid_ki"_key_hash;
+constexpr uint32_t LINEAR_POSE_PID_KD_KEY = "linear_pose_pid_kd"_key_hash;
+// Angular pose PID
+constexpr uint32_t ANGULAR_POSE_PID_KP_KEY = "angular_pose_pid_kp"_key_hash;
+constexpr uint32_t ANGULAR_POSE_PID_KI_KEY = "angular_pose_pid_ki"_key_hash;
+constexpr uint32_t ANGULAR_POSE_PID_KD_KEY = "angular_pose_pid_kd"_key_hash;
+// Linear speed PID
+constexpr uint32_t LINEAR_SPEED_PID_KP_KEY = "linear_speed_pid_kp"_key_hash;
+constexpr uint32_t LINEAR_SPEED_PID_KI_KEY = "linear_speed_pid_ki"_key_hash;
+constexpr uint32_t LINEAR_SPEED_PID_KD_KEY = "linear_speed_pid_kd"_key_hash;
+// Angular speed PID
+constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
+constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
+constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
+
+// Tracker linear pose PID
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KP_KEY = "tracker_linear_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KI_KEY = "tracker_linear_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KD_KEY = "tracker_linear_pose_pid_kd"_key_hash;
+// Tracker angular pose PID
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KP_KEY = "tracker_angular_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KI_KEY = "tracker_angular_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KD_KEY = "tracker_angular_pose_pid_kd"_key_hash;
+// Tracker linear speed PID
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KP_KEY = "tracker_linear_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KI_KEY = "tracker_linear_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_kd"_key_hash;
+// Tracker angular speed PID
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
+
+// ============================================================================
+// Parameter objects (default values from robot-specific app_conf.hpp)
+// ============================================================================
+// clang-format off
+/// Quadrature decoding polarity
+inline Parameter<float, ReadOnly> qdec_left_polarity{default_qdec_left_polarity};
+inline Parameter<float, ReadOnly> qdec_right_polarity{default_qdec_right_polarity};
+
+/// Encoder parameters
+inline Parameter<float> left_encoder_wheels_diameter_mm{default_left_encoder_wheels_diameter_mm};
+inline Parameter<float> right_encoder_wheels_diameter_mm{default_right_encoder_wheels_diameter_mm};
+inline Parameter<float> encoder_wheels_distance_mm{default_encoder_wheels_distance_mm};
+inline Parameter<float, ReadOnly> encoder_wheels_resolution_pulses{default_encoder_wheels_resolution_pulses};
+
+// Linear pose PID (QUADPID chain)
+inline Parameter<float, NonNegative> linear_pose_pid_kp{default_linear_pose_pid_kp};
+inline Parameter<float, NonNegative> linear_pose_pid_ki{default_linear_pose_pid_ki};
+inline Parameter<float, NonNegative> linear_pose_pid_kd{default_linear_pose_pid_kd};
+// Angular pose PID (QUADPID chain)
+inline Parameter<float, NonNegative> angular_pose_pid_kp{default_angular_pose_pid_kp};
+inline Parameter<float, NonNegative> angular_pose_pid_ki{default_angular_pose_pid_ki};
+inline Parameter<float, NonNegative> angular_pose_pid_kd{default_angular_pose_pid_kd};
+// Linear speed PID (QUADPID chain)
+inline Parameter<float, NonNegative> linear_speed_pid_kp{default_linear_speed_pid_kp};
+inline Parameter<float, NonNegative> linear_speed_pid_ki{default_linear_speed_pid_ki};
+inline Parameter<float, NonNegative> linear_speed_pid_kd{default_linear_speed_pid_kd};
+// Angular speed PID (QUADPID chain)
+inline Parameter<float, NonNegative> angular_speed_pid_kp{default_angular_speed_pid_kp};
+inline Parameter<float, NonNegative> angular_speed_pid_ki{default_angular_speed_pid_ki};
+inline Parameter<float, NonNegative> angular_speed_pid_kd{default_angular_speed_pid_kd};
+
+// Tracker linear pose PID
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_kp{default_tracker_linear_pose_pid_kp};
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_ki{default_tracker_linear_pose_pid_ki};
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_kd{default_tracker_linear_pose_pid_kd};
+// Tracker angular pose PID
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_kp{default_tracker_angular_pose_pid_kp};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_ki{default_tracker_angular_pose_pid_ki};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_kd{default_tracker_angular_pose_pid_kd};
+// Tracker linear speed PID
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_kp{default_tracker_linear_speed_pid_kp};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_ki{default_tracker_linear_speed_pid_ki};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_kd{default_tracker_linear_speed_pid_kd};
+// Tracker angular speed PID
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_kp{default_tracker_angular_speed_pid_kp};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
+
+// PID integral limits
+inline Parameter<float, NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> angular_pose_pid_integral_limit{default_angular_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> linear_speed_pid_integral_limit{default_linear_speed_pid_integral_limit};
+inline Parameter<float, NonNegative> angular_speed_pid_integral_limit{default_angular_speed_pid_integral_limit};
+
+// Tracker PID integral limits
+inline Parameter<float, NonNegative> tracker_linear_pose_pid_integral_limit{default_tracker_linear_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
+inline Parameter<float, NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+// clang-format on
+// ============================================================================
+// Parameter registry handlers (canpb)
+// ============================================================================
 
 namespace cogip {
 namespace pf {
 namespace motion_control {
 
 /// @brief Handle parameter get request from canpb
-///
-/// @note Processes a parameter get request received via CAN bus, retrieves the requested
-///       parameter value from the registry, and sends back a response.
-///
-/// @param[in] buffer CAN protocol buffer containing the serialized parameter get request
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer);
 
 /// @brief Handle parameter set request from CAN bus
-///
-/// @note Processes a parameter set request received via CAN bus, updates the parameter
-///       value in the registry, and sends back a response with the operation status.
-///
-/// @param[in] buffer CAN protocol buffer containing the serialized parameter set request
 void pf_handle_parameter_set(cogip::canpb::ReadBuffer& buffer);
 
 } // namespace motion_control

--- a/platforms/pf-robot-motion-control/include/platform.hpp
+++ b/platforms/pf-robot-motion-control/include/platform.hpp
@@ -49,6 +49,8 @@ using cogip::pf_common::state_uuid;
 // Service: 0x3000 - 0x3FFF
 using cogip::pf_common::parameter_get_response_uuid;
 using cogip::pf_common::parameter_get_uuid;
+using cogip::pf_common::parameter_reset_response_uuid;
+using cogip::pf_common::parameter_reset_uuid;
 using cogip::pf_common::parameter_set_response_uuid;
 using cogip::pf_common::parameter_set_uuid;
 using cogip::pf_common::reset_uuid;

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -623,6 +623,9 @@ void pf_enable_motion_control()
 
 void pf_init_motion_control(void)
 {
+    // Load parameters from flash persistent storage
+    pf_load_parameters();
+
     // Init motors
     left_motor.init();
     right_motor.init();

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -8,7 +8,6 @@
 
 // Project includes
 #include "app.hpp"
-#include "app_conf.hpp"
 #include "board.h"
 #include "drive_controller/DifferentialDriveController.hpp"
 #include "drive_controller/DifferentialDriveControllerParameters.hpp"

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -619,6 +619,9 @@ void pf_enable_motion_control()
 
 void pf_init_motion_control(void)
 {
+    // Load parameters from flash persistent storage
+    pf_load_parameters();
+
     // Init motors
     left_motor.init();
     right_motor.init();

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -7,7 +7,6 @@
 
 // Project includes
 #include "app.hpp"
-#include "app_conf.hpp"
 #include "board.h"
 #include "drive_controller/DifferentialDriveController.hpp"
 #include "drive_controller/DifferentialDriveControllerParameters.hpp"
@@ -31,6 +30,32 @@
 #include "PB_SpeedOrder.hpp"
 #include "PB_State.hpp"
 #include "telemetry/Telemetry.hpp"
+
+// Odometry: select the localization implementation at compile time.
+// robot2_conf.hpp defines ROBOT_HAS_OTOS; every other robot falls back
+// to encoder-based LocalizationDifferential. Kept at file scope so the
+// nested namespace resolution stays clean in the per-robot headers.
+#ifdef ROBOT_HAS_OTOS
+#include "localization/LocalizationOTOS.hpp"
+#include "otos/OTOS.hpp"
+static cogip::localization::LocalizationOTOS::Parameters
+    otos_params(otos_linear_scalar, otos_angular_scalar, otos_offset_x_mm, otos_offset_y_mm,
+                otos_offset_h_deg);
+static cogip::otos::OTOS otos_sensor(SOFT_I2C_DEV(0), otos_i2c_addr);
+static cogip::localization::LocalizationOTOS robot_localization(otos_sensor, otos_params);
+#else
+#include "encoder/EncoderQDEC.hpp"
+#include "localization/LocalizationDifferential.hpp"
+static cogip::encoder::EncoderQDEC left_encoder(MOTOR_LEFT, COGIP_BOARD_ENCODER_MODE,
+                                                encoder_wheels_resolution_pulses.get());
+static cogip::encoder::EncoderQDEC right_encoder(MOTOR_RIGHT, COGIP_BOARD_ENCODER_MODE,
+                                                 encoder_wheels_resolution_pulses.get());
+static cogip::localization::LocalizationDifferentialParameters
+    localization_params(left_encoder_wheels_diameter_mm, right_encoder_wheels_diameter_mm,
+                        encoder_wheels_distance_mm, qdec_left_polarity, qdec_right_polarity);
+static cogip::localization::LocalizationDifferential
+    robot_localization(localization_params, left_encoder, right_encoder);
+#endif
 
 namespace cogip {
 

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -120,6 +120,15 @@ void pf_handle_parameter_set(cogip::canpb::ReadBuffer& buffer)
     }
 }
 
+void pf_handle_parameter_reset(cogip::canpb::ReadBuffer& buffer)
+{
+    auto response = parameter_handler.handle_reset(buffer);
+    // Only respond if this board owns the parameter
+    if (response.has_value()) {
+        pf_get_canpb().send_message(parameter_reset_response_uuid, &response.value());
+    }
+}
+
 } // namespace motion_control
 } // namespace pf
 } // namespace cogip

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -8,8 +8,6 @@
 
 // Project includes
 #include "motion_control_parameters.hpp"
-#include "KeyHash.hpp"
-#include "app_conf.hpp"
 #include "parameter_handler/ParameterHandler.hpp"
 #include "platform.hpp"
 
@@ -17,47 +15,8 @@ namespace cogip {
 namespace pf {
 namespace motion_control {
 
-using namespace cogip::parameter;
-using cogip::utils::operator"" _key_hash;
-
-/// @brief Parameter key hashes for identification
-///
-/// @note Each parameter is identified by a unique 32-bit hash computed from its string key.
-
 /// Maximum number of parameters in the registry
 constexpr size_t MAX_PARAMETERS_NUMBER = 32;
-
-/// Odometry parameters keys
-constexpr uint32_t QDEC_LEFT_POLARITY_KEY = "qdec_left_polarity"_key_hash;
-constexpr uint32_t QDEC_RIGHT_POLARITY_KEY = "qdec_right_polarity"_key_hash;
-constexpr uint32_t LEFT_WHEEL_DIAMETER_KEY = "left_wheel_diameter_mm"_key_hash;
-constexpr uint32_t RIGHT_WHEEL_DIAMETER_KEY = "right_wheel_diameter_mm"_key_hash;
-constexpr uint32_t ENCODER_WHEELS_DISTANCE_KEY = "encoder_wheels_distance_mm"_key_hash;
-constexpr uint32_t ENCODER_WHEELS_RESOLUTION_KEY = "encoder_wheels_resolution_pulses"_key_hash;
-
-// PID parameters keys
-// Linear pose PID
-constexpr uint32_t LINEAR_POSE_PID_KP_KEY = "linear_pose_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KI_KEY = "linear_pose_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KD_KEY = "linear_pose_pid_kd"_key_hash;
-// Angular pose PID
-constexpr uint32_t ANGULAR_POSE_PID_KP_KEY = "angular_pose_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KI_KEY = "angular_pose_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KD_KEY = "angular_pose_pid_kd"_key_hash;
-// Linear speed PID
-constexpr uint32_t LINEAR_SPEED_PID_KP_KEY = "linear_speed_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KI_KEY = "linear_speed_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KD_KEY = "linear_speed_pid_kd"_key_hash;
-// Angular speed PID
-constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
-
-#ifdef ROBOT_HAS_OTOS
-// OTOS localization calibration scalars
-constexpr uint32_t OTOS_LINEAR_SCALAR_KEY = "otos_linear_scalar"_key_hash;
-constexpr uint32_t OTOS_ANGULAR_SCALAR_KEY = "otos_angular_scalar"_key_hash;
-#endif
 
 // Parameter handler type
 using ParameterHandlerType = parameter_handler::ParameterHandler<MAX_PARAMETERS_NUMBER>;

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -6,7 +6,11 @@
 /// @file motion_control_parameters.cpp
 /// @brief Motion control parameters registry and handlers implementation.
 
+// Set to 1 to dump every registered parameter and its post-load value at boot.
+#define ENABLE_DEBUG 0
+
 // RIOT includes
+#include "debug.h"
 #include "log.h"
 
 // Project includes
@@ -94,10 +98,59 @@ static ParameterHandlerType parameter_handler(registry);
 void pf_load_parameters()
 {
     for (auto& entry : registry) {
+#if ENABLE_DEBUG
+        // Snapshot the default before load(): at construction value_ == default_value_.
+        PB_ParameterValue pb_default;
+        entry.second.pb_copy(pb_default);
+#endif
         if (!entry.second.load()) {
             LOG_WARNING("Parameter 0x%08" PRIx32 ": flash load failed, using default\n",
                         entry.first);
         }
+#if ENABLE_DEBUG
+        PB_ParameterValue pb_value;
+        if (!entry.second.pb_copy(pb_value)) {
+            DEBUG("Parameter 0x%08" PRIx32 ": pb_copy failed\n", entry.first);
+            continue;
+        }
+        using FN = PB_ParameterValue::FieldNumber;
+        switch (pb_value.get_which_value()) {
+        case FN::FLOAT_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %f (default=%f) (float)\n", entry.first,
+                  static_cast<double>(pb_value.float_value()),
+                  static_cast<double>(pb_default.float_value()));
+            break;
+        case FN::DOUBLE_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %f (default=%f) (double)\n", entry.first,
+                  pb_value.double_value(), pb_default.double_value());
+            break;
+        case FN::INT32_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %" PRId32 " (default=%" PRId32 ") (int32)\n",
+                  entry.first, pb_value.int32_value(), pb_default.int32_value());
+            break;
+        case FN::UINT32_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %" PRIu32 " (default=%" PRIu32 ") (uint32)\n",
+                  entry.first, pb_value.uint32_value(), pb_default.uint32_value());
+            break;
+        case FN::INT64_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %" PRId64 " (default=%" PRId64 ") (int64)\n",
+                  entry.first, pb_value.int64_value(), pb_default.int64_value());
+            break;
+        case FN::UINT64_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %" PRIu64 " (default=%" PRIu64 ") (uint64)\n",
+                  entry.first, pb_value.uint64_value(), pb_default.uint64_value());
+            break;
+        case FN::BOOL_VALUE:
+            DEBUG("Parameter 0x%08" PRIx32 " = %s (default=%s) (bool)\n", entry.first,
+                  pb_value.bool_value() ? "true" : "false",
+                  pb_default.bool_value() ? "true" : "false");
+            break;
+        case FN::NOT_SET:
+        default:
+            DEBUG("Parameter 0x%08" PRIx32 " = <unset>\n", entry.first);
+            break;
+        }
+#endif
     }
     LOG_INFO("All parameters loaded (%u entries)\n", static_cast<unsigned>(registry.size()));
 }

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -74,6 +74,19 @@ static const ParameterHandlerType::Registry registry = {
     {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
     {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
     {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
+    /// Pose straight filter thresholds
+    {LINEAR_THRESHOLD_KEY, param_linear_threshold},
+    {ANGULAR_THRESHOLD_KEY, param_angular_threshold},
+    {ANGULAR_INTERMEDIATE_THRESHOLD_KEY, param_angular_intermediate_threshold},
+    /// Speed and acceleration limits
+    {MIN_SPEED_LINEAR_KEY, param_min_speed_linear},
+    {MAX_SPEED_LINEAR_KEY, param_max_speed_linear},
+    {MAX_ACC_LINEAR_KEY, param_max_acc_linear},
+    {MAX_DEC_LINEAR_KEY, param_max_dec_linear},
+    {MIN_SPEED_ANGULAR_KEY, param_min_speed_angular},
+    {MAX_SPEED_ANGULAR_KEY, param_max_speed_angular},
+    {MAX_ACC_ANGULAR_KEY, param_max_acc_angular},
+    {MAX_DEC_ANGULAR_KEY, param_max_dec_angular},
 };
 
 static ParameterHandlerType parameter_handler(registry);

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -69,6 +69,19 @@ static const ParameterHandlerType::Registry registry = {
     {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
     {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
     {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
+    /// Pose straight filter thresholds
+    {LINEAR_THRESHOLD_KEY, param_linear_threshold},
+    {ANGULAR_THRESHOLD_KEY, param_angular_threshold},
+    {ANGULAR_INTERMEDIATE_THRESHOLD_KEY, param_angular_intermediate_threshold},
+    /// Speed and acceleration limits
+    {MIN_SPEED_LINEAR_KEY, param_min_speed_linear},
+    {MAX_SPEED_LINEAR_KEY, param_max_speed_linear},
+    {MAX_ACC_LINEAR_KEY, param_max_acc_linear},
+    {MAX_DEC_LINEAR_KEY, param_max_dec_linear},
+    {MIN_SPEED_ANGULAR_KEY, param_min_speed_angular},
+    {MAX_SPEED_ANGULAR_KEY, param_max_speed_angular},
+    {MAX_ACC_ANGULAR_KEY, param_max_acc_angular},
+    {MAX_DEC_ANGULAR_KEY, param_max_dec_angular},
 };
 
 static ParameterHandlerType parameter_handler(registry);

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -8,8 +8,6 @@
 
 // Project includes
 #include "motion_control_parameters.hpp"
-#include "KeyHash.hpp"
-#include "app_conf.hpp"
 #include "parameter_handler/ParameterHandler.hpp"
 #include "platform.hpp"
 
@@ -17,41 +15,8 @@ namespace cogip {
 namespace pf {
 namespace motion_control {
 
-using namespace cogip::parameter;
-using cogip::utils::operator"" _key_hash;
-
-/// @brief Parameter key hashes for identification
-///
-/// @note Each parameter is identified by a unique 32-bit hash computed from its string key.
-
 /// Maximum number of parameters in the registry
 constexpr size_t MAX_PARAMETERS_NUMBER = 32;
-
-/// Odometry parameters keys
-constexpr uint32_t QDEC_LEFT_POLARITY_KEY = "qdec_left_polarity"_key_hash;
-constexpr uint32_t QDEC_RIGHT_POLARITY_KEY = "qdec_right_polarity"_key_hash;
-constexpr uint32_t LEFT_WHEEL_DIAMETER_KEY = "left_wheel_diameter_mm"_key_hash;
-constexpr uint32_t RIGHT_WHEEL_DIAMETER_KEY = "right_wheel_diameter_mm"_key_hash;
-constexpr uint32_t ENCODER_WHEELS_DISTANCE_KEY = "encoder_wheels_distance_mm"_key_hash;
-constexpr uint32_t ENCODER_WHEELS_RESOLUTION_KEY = "encoder_wheels_resolution_pulses"_key_hash;
-
-// PID parameters keys
-// Linear pose PID
-constexpr uint32_t LINEAR_POSE_PID_KP_KEY = "linear_pose_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KI_KEY = "linear_pose_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KD_KEY = "linear_pose_pid_kd"_key_hash;
-// Angular pose PID
-constexpr uint32_t ANGULAR_POSE_PID_KP_KEY = "angular_pose_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KI_KEY = "angular_pose_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KD_KEY = "angular_pose_pid_kd"_key_hash;
-// Linear speed PID
-constexpr uint32_t LINEAR_SPEED_PID_KP_KEY = "linear_speed_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KI_KEY = "linear_speed_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KD_KEY = "linear_speed_pid_kd"_key_hash;
-// Angular speed PID
-constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
 
 // Parameter handler type
 using ParameterHandlerType = parameter_handler::ParameterHandler<MAX_PARAMETERS_NUMBER>;

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -6,6 +6,9 @@
 /// @file motion_control_parameters.cpp
 /// @brief Motion control parameters registry and handlers implementation.
 
+// RIOT includes
+#include "log.h"
+
 // Project includes
 #include "motion_control_parameters.hpp"
 #include "parameter_handler/ParameterHandler.hpp"
@@ -16,7 +19,7 @@ namespace pf {
 namespace motion_control {
 
 /// Maximum number of parameters in the registry
-constexpr size_t MAX_PARAMETERS_NUMBER = 32;
+constexpr size_t MAX_PARAMETERS_NUMBER = 64;
 
 // Parameter handler type
 using ParameterHandlerType = parameter_handler::ParameterHandler<MAX_PARAMETERS_NUMBER>;
@@ -32,26 +35,54 @@ static const ParameterHandlerType::Registry registry = {
     {RIGHT_WHEEL_DIAMETER_KEY, right_encoder_wheels_diameter_mm},
     {ENCODER_WHEELS_DISTANCE_KEY, encoder_wheels_distance_mm},
     {ENCODER_WHEELS_RESOLUTION_KEY, encoder_wheels_resolution_pulses},
-    /// PID parameters
+    /// QuadPID chain PID parameters
     // Linear pose PID
-    {LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
-    {LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
-    {LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
+    {LINEAR_POSE_PID_KP_KEY, linear_pose_pid_kp},
+    {LINEAR_POSE_PID_KI_KEY, linear_pose_pid_ki},
+    {LINEAR_POSE_PID_KD_KEY, linear_pose_pid_kd},
     // Angular pose PID
-    {ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
-    {ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
-    {ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
+    {ANGULAR_POSE_PID_KP_KEY, angular_pose_pid_kp},
+    {ANGULAR_POSE_PID_KI_KEY, angular_pose_pid_ki},
+    {ANGULAR_POSE_PID_KD_KEY, angular_pose_pid_kd},
     // Linear speed PID
-    {LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
-    {LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
-    {LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
+    {LINEAR_SPEED_PID_KP_KEY, linear_speed_pid_kp},
+    {LINEAR_SPEED_PID_KI_KEY, linear_speed_pid_ki},
+    {LINEAR_SPEED_PID_KD_KEY, linear_speed_pid_kd},
     // Angular speed PID
-    {ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
-    {ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
-    {ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
+    {ANGULAR_SPEED_PID_KP_KEY, angular_speed_pid_kp},
+    {ANGULAR_SPEED_PID_KI_KEY, angular_speed_pid_ki},
+    {ANGULAR_SPEED_PID_KD_KEY, angular_speed_pid_kd},
+    /// Tracker chain PID parameters
+    // Tracker linear pose PID
+    {TRACKER_LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
+    {TRACKER_LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
+    {TRACKER_LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
+    // Tracker angular pose PID
+    {TRACKER_ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
+    {TRACKER_ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
+    {TRACKER_ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
+    // Tracker linear speed PID
+    {TRACKER_LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
+    {TRACKER_LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
+    {TRACKER_LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
+    // Tracker angular speed PID
+    {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
+    {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
+    {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
 };
 
 static ParameterHandlerType parameter_handler(registry);
+
+void pf_load_parameters()
+{
+    for (auto& entry : registry) {
+        if (!entry.second.load()) {
+            LOG_WARNING("Parameter 0x%08" PRIx32 ": flash load failed, using default\n",
+                        entry.first);
+        }
+    }
+    LOG_INFO("All parameters loaded (%u entries)\n", static_cast<unsigned>(registry.size()));
+}
 
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer)
 {

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -6,6 +6,9 @@
 /// @file motion_control_parameters.cpp
 /// @brief Motion control parameters registry and handlers implementation.
 
+// RIOT includes
+#include "log.h"
+
 // Project includes
 #include "motion_control_parameters.hpp"
 #include "parameter_handler/ParameterHandler.hpp"
@@ -16,7 +19,7 @@ namespace pf {
 namespace motion_control {
 
 /// Maximum number of parameters in the registry
-constexpr size_t MAX_PARAMETERS_NUMBER = 32;
+constexpr size_t MAX_PARAMETERS_NUMBER = 64;
 
 // Parameter handler type
 using ParameterHandlerType = parameter_handler::ParameterHandler<MAX_PARAMETERS_NUMBER>;
@@ -32,31 +35,59 @@ static const ParameterHandlerType::Registry registry = {
     {RIGHT_WHEEL_DIAMETER_KEY, right_encoder_wheels_diameter_mm},
     {ENCODER_WHEELS_DISTANCE_KEY, encoder_wheels_distance_mm},
     {ENCODER_WHEELS_RESOLUTION_KEY, encoder_wheels_resolution_pulses},
-    /// PID parameters
-    // Linear pose PID
-    {LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
-    {LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
-    {LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
-    // Angular pose PID
-    {ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
-    {ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
-    {ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
-    // Linear speed PID
-    {LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
-    {LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
-    {LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
-    // Angular speed PID
-    {ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
-    {ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
-    {ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
 #ifdef ROBOT_HAS_OTOS
     /// OTOS localization calibration scalars
     {OTOS_LINEAR_SCALAR_KEY, otos_linear_scalar},
     {OTOS_ANGULAR_SCALAR_KEY, otos_angular_scalar},
 #endif
+    /// QuadPID chain PID parameters
+    // Linear pose PID
+    {LINEAR_POSE_PID_KP_KEY, linear_pose_pid_kp},
+    {LINEAR_POSE_PID_KI_KEY, linear_pose_pid_ki},
+    {LINEAR_POSE_PID_KD_KEY, linear_pose_pid_kd},
+    // Angular pose PID
+    {ANGULAR_POSE_PID_KP_KEY, angular_pose_pid_kp},
+    {ANGULAR_POSE_PID_KI_KEY, angular_pose_pid_ki},
+    {ANGULAR_POSE_PID_KD_KEY, angular_pose_pid_kd},
+    // Linear speed PID
+    {LINEAR_SPEED_PID_KP_KEY, linear_speed_pid_kp},
+    {LINEAR_SPEED_PID_KI_KEY, linear_speed_pid_ki},
+    {LINEAR_SPEED_PID_KD_KEY, linear_speed_pid_kd},
+    // Angular speed PID
+    {ANGULAR_SPEED_PID_KP_KEY, angular_speed_pid_kp},
+    {ANGULAR_SPEED_PID_KI_KEY, angular_speed_pid_ki},
+    {ANGULAR_SPEED_PID_KD_KEY, angular_speed_pid_kd},
+    /// Tracker chain PID parameters
+    // Tracker linear pose PID
+    {TRACKER_LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
+    {TRACKER_LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
+    {TRACKER_LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
+    // Tracker angular pose PID
+    {TRACKER_ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
+    {TRACKER_ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
+    {TRACKER_ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
+    // Tracker linear speed PID
+    {TRACKER_LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
+    {TRACKER_LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
+    {TRACKER_LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
+    // Tracker angular speed PID
+    {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
+    {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
+    {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
 };
 
 static ParameterHandlerType parameter_handler(registry);
+
+void pf_load_parameters()
+{
+    for (auto& entry : registry) {
+        if (!entry.second.load()) {
+            LOG_WARNING("Parameter 0x%08" PRIx32 ": flash load failed, using default\n",
+                        entry.first);
+        }
+    }
+    LOG_INFO("All parameters loaded (%u entries)\n", static_cast<unsigned>(registry.size()));
+}
 
 void pf_handle_parameter_get(cogip::canpb::ReadBuffer& buffer)
 {

--- a/platforms/pf-robot-motion-control/platform.cpp
+++ b/platforms/pf-robot-motion-control/platform.cpp
@@ -24,6 +24,7 @@ static void _handle_path_add_point([[maybe_unused]] cogip::canpb::ReadBuffer& bu
 static void _handle_path_start([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
 static void _handle_parameter_get([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
 static void _handle_parameter_set([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
+static void _handle_parameter_reset([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
 static void _handle_telemetry_enable([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
 static void _handle_telemetry_disable([[maybe_unused]] cogip::canpb::ReadBuffer& buffer);
 static void _on_emergency_stop();
@@ -69,6 +70,8 @@ void pf_init(void)
                                        cogip::canpb::message_handler_t::create<_handle_parameter_get>());
         canpb.register_message_handler(parameter_set_uuid,
                                        cogip::canpb::message_handler_t::create<_handle_parameter_set>());
+        canpb.register_message_handler(parameter_reset_uuid,
+                                       cogip::canpb::message_handler_t::create<_handle_parameter_reset>());
         canpb.register_message_handler(telemetry_enable_uuid,
                                        cogip::canpb::message_handler_t::create<_handle_telemetry_enable>());
         canpb.register_message_handler(telemetry_disable_uuid,
@@ -186,6 +189,12 @@ static void _handle_parameter_get([[maybe_unused]] cogip::canpb::ReadBuffer& buf
 static void _handle_parameter_set([[maybe_unused]] cogip::canpb::ReadBuffer& buffer)
 {
     cogip::pf::motion_control::pf_handle_parameter_set(buffer);
+}
+
+/// Parameter reset message handler
+static void _handle_parameter_reset([[maybe_unused]] cogip::canpb::ReadBuffer& buffer)
+{
+    cogip::pf::motion_control::pf_handle_parameter_reset(buffer);
 }
 
 /// Telemetry enable message handler

--- a/platforms/pf-robot-motion-control/quadpid_chain.hpp
+++ b/platforms/pf-robot-motion-control/quadpid_chain.hpp
@@ -11,7 +11,6 @@
 
 #include "anti_blocking_controller/AntiBlockingController.hpp"
 #include "anti_blocking_controller/AntiBlockingControllerParameters.hpp"
-#include "app_conf.hpp"
 #include "deceleration_filter/DecelerationFilter.hpp"
 #include "deceleration_filter/DecelerationFilterIOKeys.hpp"
 #include "deceleration_filter/DecelerationFilterParameters.hpp"

--- a/platforms/pf-robot-motion-control/quadpid_tracker_chain.cpp
+++ b/platforms/pf-robot-motion-control/quadpid_tracker_chain.cpp
@@ -10,7 +10,6 @@
 
 #include "quadpid_tracker_chain.hpp"
 
-#include "app_conf.hpp"
 #include "parameter/Parameter.hpp"
 #include "pid/PID.hpp"
 #include "pid/PIDParameters.hpp"

--- a/platforms/pf-robot-motion-control/quadpid_tracker_chain.hpp
+++ b/platforms/pf-robot-motion-control/quadpid_tracker_chain.hpp
@@ -15,7 +15,6 @@
 #include "acceleration_filter/AccelerationFilterParameters.hpp"
 #include "anti_blocking_controller/AntiBlockingController.hpp"
 #include "anti_blocking_controller/AntiBlockingControllerParameters.hpp"
-#include "app_conf.hpp"
 #include "conditional_switch_meta_controller/ConditionalSwitchMetaController.hpp"
 #include "deceleration_filter/DecelerationFilter.hpp"
 #include "deceleration_filter/DecelerationFilterIOKeys.hpp"

--- a/platforms/pf-robot-motion-control/tracker_speed_tuning_chain.hpp
+++ b/platforms/pf-robot-motion-control/tracker_speed_tuning_chain.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "app_conf.hpp"
 #include "motion_control.hpp"
 #include "motion_control_common/MetaController.hpp"
 #include "polar_parallel_meta_controller/PolarParallelMetaController.hpp"

--- a/sys/parameter_handler/include/parameter_handler/ParameterHandler.hpp
+++ b/sys/parameter_handler/include/parameter_handler/ParameterHandler.hpp
@@ -118,6 +118,42 @@ template <size_t MaxParams> class ParameterHandler
         return response;
     }
 
+    /// @brief Handle parameter reset request
+    /// @param buffer CAN read buffer containing serialized PB_ParameterResetRequest
+    /// @return Optional response with operation status, empty if parameter not found locally
+    /// @note Returns empty optional if parameter not in this board's registry, allowing other
+    ///       boards on the CAN bus to respond instead. Only the board that owns the parameter
+    ///       should send a response.
+    etl::optional<PB_ParameterResetResponse> handle_reset(canpb::ReadBuffer& buffer)
+    {
+        PB_ParameterResetRequest request;
+
+        // Deserialize request
+        EmbeddedProto::Error error = request.deserialize(buffer);
+        if (error != EmbeddedProto::Error::NO_ERRORS) {
+            LOG_ERROR("Parameter reset: Protobuf deserialization error: %d\n",
+                      static_cast<int>(error));
+            return etl::nullopt;
+        }
+
+        // Check if parameter exists in the registry
+        auto it = registry_.find(request.get_key_hash());
+        if (it == registry_.end()) {
+            // Parameter not in this board's registry - don't respond
+            return etl::nullopt;
+        }
+
+        // Parameter found - erase persisted value and restore compile-time default
+        it->second.reset();
+
+        PB_ParameterResetResponse response;
+        response.set_key_hash(request.get_key_hash());
+        response.set_status(PB_ParameterStatus::SUCCESS);
+        LOG_INFO("- key_hash: 0x%08" PRIx32 ", parameter reset to default\n", it->first);
+
+        return response;
+    }
+
   private:
     const Registry& registry_;
 };

--- a/tools/check-codingrules.sh
+++ b/tools/check-codingrules.sh
@@ -40,7 +40,7 @@ done
 echo "=== CPPCHECK CHECK ==="
 
 FILES_TO_CHECK=$( sh -c "find . \( $find_exclude \) -a \( -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.hpp' \)" )
-cppcheck --std=c++17 --enable=style,performance,portability --force --error-exitcode=2 --quiet -j 1 \
+cppcheck --std=c++20 --enable=style,performance,portability --force --error-exitcode=2 --quiet -j 1 \
     --check-level=exhaustive \
     --template="{file}:{line}: {severity} ({id}): {message}"         \
     --inline-suppr ${DEFAULT_SUPPRESSIONS} ${CPPCHECK_OPTIONS} ${@}  \


### PR DESCRIPTION
## Summary

Add persistent key-value parameter storage using FlashDB, enabling motion control parameters to survive reboots without manual reconfiguration.

### Flash storage backend
- Integrate FlashDB KVDB as a singleton (`FlashKVStorage`) with mutex-based thread safety and typed `store<T>`/`load<T>` templates
- Configure MTD backends for both cogip-board (STM32 internal flash, last 8 pages / 16 KB) and cogip-native (RAM-emulated)
- Define a `settings` FAL partition on both boards
- Initialize the flash KV backend in `pf-common` so all applications get persistence automatically

### Parameter policy system
- Add `WithFlashStorage<KeyHash>` policy that persists values to flash on commit and restores them on init, using FNV-1a hashed keys
- Introduce `on_commit` / `on_init` policy trait detection with fold expressions in `PolicyTraits.hpp`
- Add `on_pb_read` / `on_pb_copy` protobuf conversion hooks with two concrete policies: `SpeedConversion` (units/s ↔ units/period) and `AccelerationConversion` (units/s² ↔ units/period²)
- Add virtual `load()` to `ParameterBase` for runtime reload without knowing the concrete type

### Motion control platform
- Centralize all `Parameter<>` declarations, key hashes, and policy composition in `motion_control_parameters.hpp` — robot config headers now only provide `constexpr` defaults
- Attach `WithFlashStorage` to all non-read-only parameters (PID gains, pose thresholds)
- Register quadpid and tracker chain PID gains in the CAN protobuf registry (fixes previous incorrect mapping)
- Add speed/acceleration limit and pose threshold parameters with transparent unit conversion at the protobuf boundary
- Load persisted values at platform init before motors and controllers start
- Remove unused `PidEnum` and related types

### Example
- Extend `parameter_demo` to exercise flash store/load/delete with the `WithFlashStorage` policy
