### PR TITLE
lift safety fixes and brake chain mechanism

### DIFF
--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -26,6 +26,13 @@ Lift::Lift(const LiftParameters& params)
 
 void Lift::init()
 {
+    // Invalidate any stale command from a previous run: init can be
+    // re-triggered over CAN, and the "else" branch below (already at
+    // lower limit) never calls actuate(), so last_command_ would
+    // otherwise keep a value from a previous session and cause the
+    // next matching actuate() to be wrongly skipped.
+    last_command_ = INT32_MIN;
+
     int ret =
         LiftsLimitSwitchesManager::instance().register_gpio(params_.lower_limit_switch_pin, this);
     if (ret) {
@@ -123,6 +130,9 @@ void Lift::at_lower_limit()
         LOG_INFO("Lower limit switch pressed\n");
         set_current_distance(params_.lower_limit_mm);
         disable();
+        // Invalidate last_command_ so the next actuate() with the same
+        // target is not skipped and can re-enable the motor.
+        last_command_ = INT32_MIN;
     } else {
         LOG_INFO("Lower limit switch released\n");
     }

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -133,8 +133,14 @@ void Lift::at_upper_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.upper_limit_switch_pin)) {
         LOG_INFO("Upper limit switch pressed\n");
-        motor_engine_.set_target_speed(0);
         motor_engine_.set_timeout_enable(false);
+        // Hold the current position. A hardware brake alone would only short
+        // the stator (dynamic braking) and cannot hold the lift against
+        // gravity, so freeze the target at the current distance and let the
+        // PID actively compensate.
+        const float current = motor_engine_.get_current_distance_from_odometer();
+        motor_engine_.set_target_distance(current);
+        last_command_ = static_cast<int32_t>(current);
     } else {
         LOG_INFO("Upper limit switch released\n");
     }

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -122,8 +122,7 @@ void Lift::at_lower_limit()
     if (gpio_read(params_.lower_limit_switch_pin)) {
         LOG_INFO("Lower limit switch pressed\n");
         set_current_distance(params_.lower_limit_mm);
-        actuate(params_.lower_limit_mm);
-        motor_engine_.set_timeout_enable(false);
+        disable();
     } else {
         LOG_INFO("Lower limit switch released\n");
     }

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -121,9 +121,7 @@ void Lift::at_lower_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.lower_limit_switch_pin)) {
         LOG_INFO("Lower limit switch pressed\n");
-        if (initializing_) {
-            set_current_distance(params_.lower_limit_mm);
-        }
+        set_current_distance(params_.lower_limit_mm);
         actuate(params_.lower_limit_mm);
         motor_engine_.set_timeout_enable(false);
     } else {

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -134,13 +134,15 @@ void Lift::at_upper_limit()
     if (gpio_read(params_.upper_limit_switch_pin)) {
         LOG_INFO("Upper limit switch pressed\n");
         motor_engine_.set_timeout_enable(false);
-        // Hold the current position. A hardware brake alone would only short
-        // the stator (dynamic braking) and cannot hold the lift against
-        // gravity, so freeze the target at the current distance and let the
-        // PID actively compensate.
-        const float current = motor_engine_.get_current_distance_from_odometer();
-        motor_engine_.set_target_distance(current);
-        last_command_ = static_cast<int32_t>(current);
+        // Latch the engine brake chain: the zero-speed-order + speed PID
+        // chain actively drives the motor toward zero speed, holding the
+        // lift against gravity without needing the full pose loop.
+        // Motor::actuate() releases the brake explicitly on a new motion
+        // request.
+        motor_engine_.set_brake(true);
+        // Invalidate last_command_ so the next actuate() with the same
+        // target is not skipped and can release the brake.
+        last_command_ = INT32_MIN;
     } else {
         LOG_INFO("Upper limit switch released\n");
     }

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -129,6 +129,14 @@ void Lift::at_lower_limit()
     if (gpio_read(params_.lower_limit_switch_pin)) {
         LOG_INFO("Lower limit switch pressed\n");
         set_current_distance(params_.lower_limit_mm);
+        // If the current command targets the lower limit, the switch
+        // pressing IS the definitive "reached" signal. Emit it before
+        // disable() cuts the engine, otherwise the engine will never
+        // run another tick to fire pose_reached_cb and the host would
+        // never hear that the target was reached.
+        if (last_command_ == params_.lower_limit_mm) {
+            on_state_change(motion_control::target_pose_status_t::reached);
+        }
         disable();
         // Invalidate last_command_ so the next actuate() with the same
         // target is not skipped and can re-enable the motor.
@@ -144,6 +152,14 @@ void Lift::at_upper_limit()
     if (gpio_read(params_.upper_limit_switch_pin)) {
         LOG_INFO("Upper limit switch pressed\n");
         motor_engine_.set_timeout_enable(false);
+        // If the current command targets the upper limit, the switch
+        // pressing IS the definitive "reached" signal. Emit it now: the
+        // brake chain takes over and does not drive the pose loop, so
+        // MotorEngine::process_outputs() cannot fire pose_reached_cb on
+        // its own from here on.
+        if (last_command_ == params_.upper_limit_mm) {
+            on_state_change(motion_control::target_pose_status_t::reached);
+        }
         // Latch the engine brake chain: the zero-speed-order + speed PID
         // chain actively drives the motor toward zero speed, holding the
         // lift against gravity without needing the full pose loop.

--- a/lib/actuator/Motor.cpp
+++ b/lib/actuator/Motor.cpp
@@ -57,6 +57,10 @@ Motor::Motor(const MotorParameters& motor_parameters, MotorControlMode mode)
                                 motor_parameters.speed_controller_parameters),
       tracker_motor_distance_filter_(actuators::motor_tracker_pose_filter_io_keys,
                                      motor_parameters.motor_pose_filter_parameters),
+      // Brake chain: zero speed_order + dedicated speed PID
+      brake_zero_speed_order_controller_({{"speed_order", 0.0f}}),
+      brake_speed_controller_(actuators::motor_speed_pid_io_keys,
+                              motor_parameters.speed_controller_parameters),
       // Motor engine
       motor_engine_(motor_parameters.motor, motor_parameters.odometer,
                     motor_parameters.engine_thread_period_ms)
@@ -106,6 +110,13 @@ Motor::Motor(const MotorParameters& motor_parameters, MotorControlMode mode)
 
         LOG_INFO("Motor using DUALPID control mode\n");
     }
+
+    // Brake chain: ZeroSpeedOrder -> SpeedPID. Runs only when engine.brake_
+    // is set; writes to the same speed_order/speed_command IO keys as the
+    // normal chain, which is fine because only one chain runs per cycle.
+    brake_meta_controller_.add_controller(&brake_zero_speed_order_controller_);
+    brake_meta_controller_.add_controller(&brake_speed_controller_);
+    motor_engine_.set_brake_controller(&brake_meta_controller_);
 
     // Init motor
     int ret = params_.motor.init();
@@ -188,6 +199,11 @@ void Motor::actuate(int32_t command)
 
     // Timeout security is setup, set target distance to reach
     motor_engine_.set_target_distance(command_);
+
+    // An explicit actuate() is a deliberate motion request: release any
+    // latched brake. EMS gates actuator commands upstream (handler-level),
+    // so this cannot silently revert an emergency stop.
+    motor_engine_.set_brake(false);
 
     // Enable engine in case it has been previously disabled by timeout
     motor_engine_.enable();

--- a/lib/actuator/PB_Actuators.proto
+++ b/lib/actuator/PB_Actuators.proto
@@ -55,3 +55,7 @@ message PB_ActuatorCommand {
         PB_PositionalActuatorCommand positional_actuator = 1;
     }
 }
+
+message PB_ActuatorInit {
+    optional PB_PositionalActuatorEnum id = 1;
+}

--- a/lib/actuator/PositionalActuator.cpp
+++ b/lib/actuator/PositionalActuator.cpp
@@ -28,7 +28,7 @@ void PositionalActuator::pb_copy(PB_PositionalActuator& pb_positional_actuator) 
 {
     pb_positional_actuator.set_id(static_cast<PB_PositionalActuatorEnum>(id_));
     pb_positional_actuator.set_state(static_cast<PB_PositionalActuatorStateEnum>(state_));
-    pb_positional_actuator.set_position(command_);
+    pb_positional_actuator.set_position(get_position());
 }
 
 } // namespace positional_actuators

--- a/lib/actuator/include/actuator/Motor.hpp
+++ b/lib/actuator/include/actuator/Motor.hpp
@@ -22,6 +22,7 @@
 #include "motor_pose_filter/MotorPoseFilterParameters.hpp"
 #include "pose_pid_controller/PosePIDController.hpp"
 #include "pose_pid_controller/PosePIDControllerParameters.hpp"
+#include "reset_controller/ResetController.hpp"
 #include "speed_filter/SpeedFilter.hpp"
 #include "speed_filter/SpeedFilterParameters.hpp"
 #include "speed_pid_controller/SpeedPIDController.hpp"
@@ -172,6 +173,20 @@ class Motor : public PositionalActuator
 
     /// Anti-blocking controller - detects motor stall (optional).
     etl::optional<motion_control::AntiBlockingController> anti_blocking_controller_;
+
+    // =========================================================================
+    // Brake chain (minimal active-stop chain, runs while engine.brake_ is set)
+    // =========================================================================
+
+    /// Forces speed_order = 0 at the head of the brake chain.
+    motion_control::ResetController brake_zero_speed_order_controller_;
+
+    /// Dedicated speed PID for the brake chain (cannot reuse the normal one
+    /// because a controller can belong to only one meta-controller).
+    motion_control::SpeedPIDController brake_speed_controller_;
+
+    /// Meta controller chaining the zero-speed-order reset and the speed PID.
+    motion_control::DualPIDMetaController brake_meta_controller_;
 
     // =========================================================================
     // Common components

--- a/lib/actuator/include/actuator/Motor.hpp
+++ b/lib/actuator/include/actuator/Motor.hpp
@@ -100,6 +100,12 @@ class Motor : public PositionalActuator
     /// @return Current distance in mm.
     float get_current_distance() const;
 
+    /// @brief Report the current measured distance as the CAN position.
+    int32_t get_position() const override
+    {
+        return static_cast<int32_t>(get_current_distance());
+    }
+
     /// @brief Manually override the current distance reading.
     /// @param distance New distance in mm.
     void set_current_distance(float distance);

--- a/lib/actuator/include/actuator/PositionalActuator.hpp
+++ b/lib/actuator/include/actuator/PositionalActuator.hpp
@@ -87,6 +87,15 @@ class PositionalActuator : public Actuator
         state_ = state;
     }
 
+    /// @brief Return the value reported as the actuator position over CAN.
+    /// @details Defaults to the last commanded value. Subclasses with a real
+    /// measurement (e.g. encoder) should override to report the actual
+    /// current position.
+    virtual int32_t get_position() const
+    {
+        return command_;
+    }
+
   protected:
     /// Current actuator command as a duty cycle percentage.
     int32_t command_;

--- a/motion_control/motion_control_common/BaseControllerEngine.cpp
+++ b/motion_control/motion_control_common/BaseControllerEngine.cpp
@@ -20,7 +20,7 @@ namespace motion_control {
 BaseControllerEngine::BaseControllerEngine(uint32_t engine_thread_period_ms)
     : enable_(true), controller_(nullptr), current_cycle_(0), pose_reached_(moving),
       timeout_cycle_counter_(0), timeout_ms_(0), timeout_enable_(false),
-      engine_thread_period_ms_(engine_thread_period_ms)
+      engine_thread_period_ms_(engine_thread_period_ms), brake_(false), brake_controller_(nullptr)
 {
     memset(engine_thread_stack_, 0, sizeof(engine_thread_stack_));
     mutex_init(&mutex_);
@@ -58,24 +58,29 @@ void BaseControllerEngine::thread_loop()
         // Clear modified flags
         io_.clear_modified();
 
-        if ((enable_) && (controller_)) {
+        if (enable_) {
+            if (brake_ && brake_controller_) {
+                // Brake latched: run the minimal brake chain and let
+                // process_outputs drive the motor(s) toward zero speed.
+                brake_controller_->execute(io_);
+            } else if (controller_) {
+                // Execute controller
+                controller_->execute(io_);
 
-            // Execute controller
-            controller_->execute(io_);
+                // Next cycle
+                current_cycle_++;
 
-            // Next cycle
-            current_cycle_++;
+                // Consider pose reached on timeout
+                if ((timeout_enable_) && (--timeout_cycle_counter_ <= 0)) {
+                    // Reset timeout cycles counter
+                    timeout_cycle_counter_ = timeout_ms_ / engine_thread_period_ms_;
+                    // Force target pose status to notify the platform the timeout is over
+                    pose_reached_ = target_pose_status_t::timeout;
 
-            // Consider pose reached on timeout
-            if ((timeout_enable_) && (--timeout_cycle_counter_ <= 0)) {
-                // Reset timeout cycles counter
-                timeout_cycle_counter_ = timeout_ms_ / engine_thread_period_ms_;
-                // Force target pose status to notify the platform the timeout is over
-                pose_reached_ = target_pose_status_t::timeout;
+                    LOG_ERROR("Engine timed out\n");
 
-                LOG_ERROR("Engine timed out\n");
-
-                enable_ = false;
+                    enable_ = false;
+                }
             }
 
             // Process controller outputs

--- a/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
@@ -63,10 +63,41 @@ class BaseControllerEngine
         return enable_;
     };
 
+    /// Latch or clear the brake state. When latched, the engine executes
+    /// the brake controller chain instead of the normal one; it stays
+    /// latched until an explicit set_brake(false) is issued.
+    void set_brake(bool brake)
+    {
+        mutex_lock(&mutex_);
+        brake_ = brake;
+        mutex_unlock(&mutex_);
+    };
+
+    /// Return whether the brake is currently latched
+    bool is_braking() const
+    {
+        return brake_;
+    };
+
+    /// Register the controller chain to execute while brake is latched.
+    /// Intended to be a minimal chain writing speed_order = 0 followed
+    /// by the speed loop, so that process_outputs drives the motor(s)
+    /// toward zero speed via closed-loop control.
+    void set_brake_controller(BaseController* brake_controller)
+    {
+        brake_controller_ = brake_controller;
+    };
+
     /// Get controller
     BaseController* controller() const
     {
         return controller_;
+    };
+
+    /// Get brake controller
+    BaseController* brake_controller() const
+    {
+        return brake_controller_;
     };
 
     /// Get pose reached flag
@@ -192,6 +223,14 @@ class BaseControllerEngine
 
     /// Controllers input/output datas shared accross controllers
     ControllersIO io_;
+
+    /// Brake latch flag. When true, the engine runs brake_controller_ each
+    /// cycle instead of controller_. Cleared only by an explicit
+    /// set_brake(false) call.
+    bool brake_;
+
+    /// Controller chain executed while brake_ is latched.
+    BaseController* brake_controller_;
 };
 
 } // namespace motion_control

--- a/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
@@ -57,6 +57,12 @@ class BaseControllerEngine
         mutex_unlock(&mutex_);
     };
 
+    /// Return whether the engine is enabled
+    bool is_enabled() const
+    {
+        return enable_;
+    };
+
     /// Get controller
     BaseController* controller() const
     {

--- a/platforms/pf-robot-motion-control/brake_chain.cpp
+++ b/platforms/pf-robot-motion-control/brake_chain.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @file
+/// @brief Brake chain wiring for the platform engine
+
+#include "brake_chain.hpp"
+
+#include "motion_control.hpp"
+
+namespace cogip {
+namespace pf {
+namespace motion_control {
+
+namespace brake_chain {
+
+void init()
+{
+    // Speed loop: parallel linear + angular PIDs.
+    brake_speed_loop_polar_parallel.add_controller(&brake_linear_speed_controller);
+    brake_speed_loop_polar_parallel.add_controller(&brake_angular_speed_controller);
+
+    // Chain: force speed orders to 0, then run the speed loop.
+    brake_meta_controller.add_controller(&brake_zero_speed_order_controller);
+    brake_meta_controller.add_controller(&brake_speed_loop_polar_parallel);
+
+    // Registration with the platform engine is done by the motion_control
+    // module, which owns the engine instance.
+}
+
+} // namespace brake_chain
+
+} // namespace motion_control
+} // namespace pf
+} // namespace cogip

--- a/platforms/pf-robot-motion-control/brake_chain.hpp
+++ b/platforms/pf-robot-motion-control/brake_chain.hpp
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 COGIP Robotics association <cogip35@gmail.com>
+// This file is subject to the terms and conditions of the GNU Lesser
+// General Public License v2.1. See the file LICENSE in the top level
+// directory for more details.
+
+/// @file
+/// @brief Brake chain controller instances for the platform engine
+/// @details Minimal controller chain executed while the engine brake is
+/// latched. Forces linear and angular speed orders to zero and runs the speed
+/// loop, so process_outputs drives the motors toward zero speed via
+/// closed-loop control. Used for controlled active stop, not for emergency
+/// stop (EMS still disables motors).
+
+#pragma once
+
+#include "app_conf.hpp"
+#include "motion_control_common/MetaController.hpp"
+#include "pid/PID.hpp"
+#include "polar_parallel_meta_controller/PolarParallelMetaController.hpp"
+#include "reset_controller/ResetController.hpp"
+#include "speed_pid_controller/SpeedPIDController.hpp"
+#include "speed_pid_controller/SpeedPIDControllerIOKeysDefault.hpp"
+#include "speed_pid_controller/SpeedPIDControllerParameters.hpp"
+
+// Pull in the shared PID parameter instances used by the normal speed loop;
+// the brake chain starts with the same gains, tuning can be done later.
+#include "quadpid_chain.hpp"
+
+namespace cogip {
+namespace pf {
+namespace motion_control {
+
+namespace brake_chain {
+
+// Dedicated PID state for the brake speed loop. Gains come from the same
+// parameters as the normal speed loop, but the integrator / previous-error
+// state must not be shared so that activating the brake does not pollute
+// (or get polluted by) the running chain.
+inline cogip::pid::PID brake_linear_speed_pid(quadpid_chain::linear_speed_pid_parameters);
+inline cogip::pid::PID brake_angular_speed_pid(quadpid_chain::angular_speed_pid_parameters);
+
+inline cogip::motion_control::SpeedPIDControllerParameters
+    brake_linear_speed_controller_parameters(&brake_linear_speed_pid);
+inline cogip::motion_control::SpeedPIDControllerParameters
+    brake_angular_speed_controller_parameters(&brake_angular_speed_pid);
+
+// Dedicated SpeedPIDController instances. IO keys are identical to the
+// normal chain because only one chain runs per cycle; the ownership rule
+// (a controller can only belong to one meta-controller) forces duplication.
+inline cogip::motion_control::SpeedPIDController brake_linear_speed_controller(
+    cogip::motion_control::linear_speed_pid_controller_io_keys_default,
+    brake_linear_speed_controller_parameters);
+inline cogip::motion_control::SpeedPIDController brake_angular_speed_controller(
+    cogip::motion_control::angular_speed_pid_controller_io_keys_default,
+    brake_angular_speed_controller_parameters);
+
+// Parallel execution of linear and angular speed loops.
+inline cogip::motion_control::PolarParallelMetaController brake_speed_loop_polar_parallel;
+
+// Forces both speed orders to zero at the head of the brake chain.
+inline cogip::motion_control::ResetController brake_zero_speed_order_controller(
+    {{"linear_speed_order", 0.0f}, {"angular_speed_order", 0.0f}});
+
+// Top-level brake chain: zero speed orders, then run the speed loop.
+inline cogip::motion_control::MetaController<> brake_meta_controller;
+
+/// Wire the brake chain sub-controllers and register it on the platform
+/// engine as its brake controller.
+void init();
+
+} // namespace brake_chain
+
+} // namespace motion_control
+} // namespace pf
+} // namespace cogip

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -24,6 +24,7 @@
 #include "platform.hpp"
 #include "platform_engine/PlatformEngine.hpp"
 
+#include "brake_chain.hpp"
 #include "quadpid_chain.hpp"
 #include "quadpid_tracker_chain.hpp"
 #include "tracker_speed_tuning_chain.hpp"
@@ -643,6 +644,8 @@ void pf_init_motion_control(void)
     quadpid_chain::init();
     quadpid_tracker_chain::init();
     tracker_speed_tuning_chain::init();
+    brake_chain::init();
+    pf_motion_control_platform_engine.set_brake_controller(&brake_chain::brake_meta_controller);
 
     // Associate default controller (QUADPID_TRACKER) to the engine
     pf_motion_control_platform_engine.set_controller(

--- a/platforms/pf-robot-motors/Makefile.dep
+++ b/platforms/pf-robot-motors/Makefile.dep
@@ -26,6 +26,7 @@ USEMODULE += dualpid_meta_controller
 USEMODULE += motor_engine
 USEMODULE += motor_pose_filter
 USEMODULE += pose_pid_controller
+USEMODULE += reset_controller
 USEMODULE += speed_pid_controller
 USEMODULE += speed_filter
 

--- a/platforms/pf-robot-motors/pf_actuators.cpp
+++ b/platforms/pf-robot-motors/pf_actuators.cpp
@@ -83,15 +83,36 @@ static void _handle_command(cogip::canpb::ReadBuffer& buffer)
     }
 }
 
-/// Actuators initialization message handler
-static void _handle_actuators_init([[maybe_unused]] cogip::canpb::ReadBuffer& buffer)
+/// Actuators initialization message handler.
+/// Without a PB_ActuatorInit payload, or with one whose id field is
+/// unset, every positional actuator is initialised (legacy behaviour).
+/// When the id field is set, only that actuator is initialised.
+static void _handle_actuators_init(cogip::canpb::ReadBuffer& buffer)
 {
     cogip::pf_common::clear_emergency_stop();
     if (cogip::pf_common::is_emergency_stop_latched()) {
         LOG_WARNING("Actuator init rejected: emergency stop button still engaged\n");
         return;
     }
-    positional_actuators::init_sequence();
+
+    static PB_ActuatorInit pb_init;
+    pb_init.clear();
+    if (buffer.get_size() > 0) {
+        pb_init.deserialize(buffer);
+    }
+
+    if (!pb_init.has_id()) {
+        positional_actuators::init_sequence();
+        return;
+    }
+
+    cogip::actuators::Enum id = cogip::actuators::Enum{static_cast<uint8_t>(pb_init.get_id())};
+    if (!positional_actuators::contains(id)) {
+        LOG_WARNING("Actuator init: id=%" PRIu8 " not found\n", static_cast<uint8_t>(id));
+        return;
+    }
+    LOG_INFO("Actuator init: id=%" PRIu8 "\n", static_cast<uint8_t>(id));
+    positional_actuators::get(id).init();
 }
 
 void init()

--- a/platforms/pf-robot-motors/platform.cpp
+++ b/platforms/pf-robot-motors/platform.cpp
@@ -17,14 +17,12 @@ static void _handle_game_start([[maybe_unused]] cogip::canpb::ReadBuffer& buffer
         LOG_WARNING("game_start rejected: emergency stop latched\n");
         return;
     }
-    cogip::pf::actuators::enable_all();
 }
 
 /// Reset game message handler
 static void _handle_game_reset([[maybe_unused]] cogip::canpb::ReadBuffer& buffer)
 {
     cogip::pf_common::clear_emergency_stop();
-    cogip::pf::actuators::enable_all();
 }
 
 /// End game message handler


### PR DESCRIPTION
## Summary

Two threads bundled on this branch:

**Lift safety fixes**
- Always recalibrate lift position when the lower limit switch triggers, not only during the init sequence.
- Drop the `actuate()` call from the lower limit switch handler: only recalibrate and disable, so the motor is not re-enabled after a controlled stop.
- On the upper limit switch, latch the engine brake chain to actively hold the lift against gravity (a passive DRV8873 hardware brake alone cannot hold the load). A freeze-target implementation is kept as a working reference in an intermediate commit before the final switch-over to the brake chain.
- `pf-robot-motors`: do not re-enable motors on game reset / game start (they may have been disabled by the user for a reason).
- `pf-robot-motors`: `actuator_init` CAN message now accepts an optional `PB_ActuatorInit { optional PB_PositionalActuatorEnum id }` payload; empty payload keeps the legacy init-all behaviour, a set id initialises only that actuator.

**Brake chain mechanism**
- `BaseControllerEngine` gains a brake latch and a brake controller chain: when the latch is set, the engine runs the brake chain instead of the normal one and still calls `process_outputs`, so the brake chain's speed command flows through to the motor driver. The latch stays set until an explicit `set_brake(false)`.
- `Motor` builds a minimal brake chain (ResetController forcing `speed_order = 0` + dedicated SpeedPIDController) and registers it on its MotorEngine. Any `Motor`-based actuator gets active-hold brake for free. `Motor::actuate()` explicitly releases the brake so a new motion request resumes normally; other mutators (`set_target_distance`, etc.) keep it latched.
- `pf-robot-motion-control` builds a brake chain for the platform engine (ResetController zeroing both polar speed orders + PolarParallel of dedicated linear and angular SpeedPIDControllers).
- The mechanism is distinct from EMS: EMS still disables motors (cuts power) and is not wired through the brake chain.

## Context

Initial trigger: with the emergency stop engaged at boot, the lift init sequence timed out and disabled the motor. When the button was released the lower limit switch fired (gravity), the handler called `actuate(0)` which re-enabled the motor with an uncalibrated 130 mm offset, producing a violent downward lunge.

While addressing that, we also saw the lift slip down at the upper limit because a passive hardware brake cannot counteract gravity, and found that `actuator_init` could not target a single lift of a dual-lift setup. The brake chain mechanism generalises active-stop / active-hold into a reusable pattern ready to be wired up for controlled robot stops (trigger left to policy; EMS keeps its current disable behaviour).
