### PR TITLE
motion_control: disambiguate tracker PID CAN keys with tracker_ prefix

### DIFF
--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -35,23 +35,23 @@ constexpr uint32_t RIGHT_WHEEL_DIAMETER_KEY = "right_wheel_diameter_mm"_key_hash
 constexpr uint32_t ENCODER_WHEELS_DISTANCE_KEY = "encoder_wheels_distance_mm"_key_hash;
 constexpr uint32_t ENCODER_WHEELS_RESOLUTION_KEY = "encoder_wheels_resolution_pulses"_key_hash;
 
-// PID parameters keys
+// PID parameters keys (tracker chain, ie. QuadPID + trajectory tracker)
 // Linear pose PID
-constexpr uint32_t LINEAR_POSE_PID_KP_KEY = "linear_pose_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KI_KEY = "linear_pose_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_POSE_PID_KD_KEY = "linear_pose_pid_kd"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KP_KEY = "tracker_linear_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KI_KEY = "tracker_linear_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_POSE_PID_KD_KEY = "tracker_linear_pose_pid_kd"_key_hash;
 // Angular pose PID
-constexpr uint32_t ANGULAR_POSE_PID_KP_KEY = "angular_pose_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KI_KEY = "angular_pose_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_POSE_PID_KD_KEY = "angular_pose_pid_kd"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KP_KEY = "tracker_angular_pose_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KI_KEY = "tracker_angular_pose_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_POSE_PID_KD_KEY = "tracker_angular_pose_pid_kd"_key_hash;
 // Linear speed PID
-constexpr uint32_t LINEAR_SPEED_PID_KP_KEY = "linear_speed_pid_kp"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KI_KEY = "linear_speed_pid_ki"_key_hash;
-constexpr uint32_t LINEAR_SPEED_PID_KD_KEY = "linear_speed_pid_kd"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KP_KEY = "tracker_linear_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KI_KEY = "tracker_linear_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_kd"_key_hash;
 // Angular speed PID
-constexpr uint32_t ANGULAR_SPEED_PID_KP_KEY = "angular_speed_pid_kp"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KI_KEY = "angular_speed_pid_ki"_key_hash;
-constexpr uint32_t ANGULAR_SPEED_PID_KD_KEY = "angular_speed_pid_kd"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
+constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
 
 // Parameter handler type
 using ParameterHandlerType = parameter_handler::ParameterHandler<MAX_PARAMETERS_NUMBER>;
@@ -69,21 +69,21 @@ static const ParameterHandlerType::Registry registry = {
     {ENCODER_WHEELS_RESOLUTION_KEY, encoder_wheels_resolution_pulses},
     /// PID parameters
     // Linear pose PID
-    {LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
-    {LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
-    {LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
+    {TRACKER_LINEAR_POSE_PID_KP_KEY, tracker_linear_pose_pid_kp},
+    {TRACKER_LINEAR_POSE_PID_KI_KEY, tracker_linear_pose_pid_ki},
+    {TRACKER_LINEAR_POSE_PID_KD_KEY, tracker_linear_pose_pid_kd},
     // Angular pose PID
-    {ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
-    {ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
-    {ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
+    {TRACKER_ANGULAR_POSE_PID_KP_KEY, tracker_angular_pose_pid_kp},
+    {TRACKER_ANGULAR_POSE_PID_KI_KEY, tracker_angular_pose_pid_ki},
+    {TRACKER_ANGULAR_POSE_PID_KD_KEY, tracker_angular_pose_pid_kd},
     // Linear speed PID
-    {LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
-    {LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
-    {LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
+    {TRACKER_LINEAR_SPEED_PID_KP_KEY, tracker_linear_speed_pid_kp},
+    {TRACKER_LINEAR_SPEED_PID_KI_KEY, tracker_linear_speed_pid_ki},
+    {TRACKER_LINEAR_SPEED_PID_KD_KEY, tracker_linear_speed_pid_kd},
     // Angular speed PID
-    {ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
-    {ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
-    {ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
+    {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
+    {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
+    {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
 };
 
 static ParameterHandlerType parameter_handler(registry);


### PR DESCRIPTION
## Summary

The CAN parameter keys for the twelve tracker-chain PIDs (`linear_pose_pid_kp`, ..., `angular_speed_pid_kd`) were exposed under their short names even though:

- They map to the `tracker_*` C++ variables declared in `robotN_conf.hpp`.
- Each `robotN_conf.hpp` also declares a separate **non-tracker** `quadpid_*` PID set under the exact same short names (for the classic QuadPID chain), which is currently not exposed over CAN but would collide the day we want to expose it.

Rename the twelve CAN key strings and their local `constexpr` identifiers to `tracker_<axis>_<loop>_pid_k*` so the wire-level key matches the C++ identifier it points at, and leaves the short form available for the QuadPID chain later.

## Companion change on the host side

The `firmware_pid_calibration` host tool already uses `tracker_*` in its bundled YAML schema (`pid_parameters.yaml`), but its `PidType.param_names` still used the short form — that's what made the tool fail with `"Firmware parameter 'angular_speed_pid_kp' not found"` in practice. Aligned in cogip-tools separately (branch `fix-pid-calibration-tracker-param-names`).

## Test plan

- [x] `make -j BOARD=cogip-native -C applications/robot-motion-control` succeeds.
- [ ] `make -j BOARD=cogip-board -C applications/robot-motion-control` succeeds (CI).
- [ ] After flashing, `cogip-pid-calibration` (with the matching cogip-tools change) can read and write each of the four tracker PIDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)