### PR TITLE
235 print firmware version inside main app

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -53,6 +53,15 @@ CXXEXFLAGS += -std=c++17
 CXXEXFLAGS += -Wno-pedantic
 CXXEXFLAGS += -Wno-cast-align
 
+# MCU firmware version: <application>@<branch-name>-g<short-sha>[-dirty]
+MCU_FW_GIT_VERSION := $(shell git describe --long --tags --always --dirty --all | sed -E -e 's/^(heads|tags)\///' -e 's/^remotes\/origin\///' -e 's/\//-/g')
+MCU_FW_BUILD_VERSION ?= $(MCU_FW_GIT_VERSION)
+CFLAGS += -DMCU_FIRMWARE_BUILD_VERSION_STRING=\"$(MCU_FW_BUILD_VERSION)\"
+
+.PHONY: print-build-fw-version
+print-build-fw-version:
+	@echo "$(MCU_FW_BUILD_VERSION)"
+
 # Export mcu-firmware global variables
 include $(MCUFIRMWAREBASE)/makefiles/global_vars.mk.inc
 

--- a/applications/power-supply-control/main.cpp
+++ b/applications/power-supply-control/main.cpp
@@ -1,8 +1,12 @@
 #include "app.hpp"
 #include "platform.hpp"
 
+#include "log.h"
+
 int main(void)
 {
+    LOG_INFO("FW version: %s\n", MCU_FIRMWARE_BUILD_VERSION_STRING);
+
     pf_init();
     app_init();
 

--- a/applications/robot-lift-control/main.cpp
+++ b/applications/robot-lift-control/main.cpp
@@ -1,8 +1,12 @@
 #include "app.hpp"
 #include "platform.hpp"
 
+#include "log.h"
+
 int main(void)
 {
+    LOG_INFO("FW version: %s\n", MCU_FIRMWARE_BUILD_VERSION_STRING);
+
     pf_init();
     cogip::app::app_init();
 

--- a/applications/robot-motion-control/main.cpp
+++ b/applications/robot-motion-control/main.cpp
@@ -1,8 +1,13 @@
 #include "app.hpp"
 #include "platform.hpp"
 
+#include "log.h"
+
 int main(void)
 {
+    LOG_INFO("FW version: %s\n", MCU_FIRMWARE_BUILD_VERSION_STRING);
+    LOG_INFO("Robot ID: %d\n", ROBOT_ID);
+
     pf_init();
     app_init();
 


### PR DESCRIPTION
build: define MCU_FIRMWARE_BUILD_VERSION_STRING from git describe
- Needed to display firmware version from application logs and identify
running firmware on each board
- Overridable via MCU_FW_BUILD_VERSION for tagged releases
- Convenience make target print-build-fw-version for scripts

applications: log firmware version at startup
- Helps identify which firmware is running on each board
  during debugging and field diagnostics without needing
  to reflash
- Motion control also logs ROBOT_ID to distinguish boards
  in multi-robot setups