### PR TITLE
Fix lift init wedge, switch direction, and dedicate a brake PID

### DIFF
--- a/applications/robot-lift-control/include/lift_common_conf.hpp
+++ b/applications/robot-lift-control/include/lift_common_conf.hpp
@@ -50,6 +50,20 @@ inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> motor_l
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
     motor_lift_speed_pid_integral_limit{static_cast<float>(etl::numeric_limits<int16_t>::max())};
 
+// Motor lift brake speed PID (used only by the brake chain to actively hold
+// the lift against gravity once a limit is reached). Higher Ki than the
+// tracking PID so the integrator builds up fast enough to counter the
+// constant gravity disturbance before the lift drifts more than a few mm.
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_kp{10.0f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_ki{2.0f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_kd{0.f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_integral_limit{
+        static_cast<float>(etl::numeric_limits<int16_t>::max())};
+
 // Motor lift threshold
 constexpr float motor_lift_threshold = 1.0;
 
@@ -138,6 +152,17 @@ inline cogip::pid::PIDParameters motor_lift_speed_pid_params(motor_lift_speed_pi
 /// @brief Motor Lift speed PID controller
 inline cogip::pid::PID motor_lift_speed_pid(motor_lift_speed_pid_params);
 
+/// @brief Motor Lift brake speed PID parameters (dedicated to the brake chain)
+inline cogip::pid::PIDParameters
+    motor_lift_brake_speed_pid_params(motor_lift_brake_speed_pid_kp,
+                                      motor_lift_brake_speed_pid_ki,
+                                      motor_lift_brake_speed_pid_kd,
+                                      motor_lift_brake_speed_pid_integral_limit);
+
+/// @brief Motor Lift brake speed PID controller (separate instance so its
+/// integrator state does not interfere with the tracking PID).
+inline cogip::pid::PID motor_lift_brake_speed_pid(motor_lift_brake_speed_pid_params);
+
 /// @brief Motor Lift MotorPoseFilterParameters
 static cogip::motion_control::MotorPoseFilterParameters
     motor_lift_pose_filter_parameters(motor_lift_threshold,
@@ -155,6 +180,10 @@ static cogip::motion_control::SpeedFilterParameters motor_lift_speed_filter_para
 /// @brief Motor Lift SpeedPIDControllerParameters.
 static cogip::motion_control::SpeedPIDControllerParameters
     motor_lift_speed_pid_parameters(&motor_lift_speed_pid);
+
+/// @brief Motor Lift brake SpeedPIDControllerParameters (dedicated to brake chain).
+static cogip::motion_control::SpeedPIDControllerParameters
+    motor_lift_brake_speed_pid_parameters(&motor_lift_brake_speed_pid);
 
 /// @brief Motor Lift ProfileTrackerControllerParameters (for DUALPID_TRACKER mode).
 /// @details Defines the trapezoidal velocity profile limits for smooth motion control.
@@ -239,6 +268,7 @@ make_lift_motor_params(cogip::actuators::Enum actuator_id, bool use_tracker_chai
         /* speed_limit_filter_params    */ &motor_lift_speed_limit_parameters,
         /* deceleration_filter_params   */ &motor_lift_deceleration_filter_parameters,
         /* anti_blocking_params         */ &motor_lift_anti_blocking_parameters,
+        /* brake_speed_controller_params*/ motor_lift_brake_speed_pid_parameters,
     };
 }
 

--- a/applications/robot-lift-control/include/lift_common_conf.hpp
+++ b/applications/robot-lift-control/include/lift_common_conf.hpp
@@ -50,6 +50,21 @@ inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> motor_l
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
     motor_lift_speed_pid_integral_limit{static_cast<float>(etl::numeric_limits<int16_t>::max())};
 
+// Motor lift brake speed PID (used only by the brake chain to actively hold
+// the lift against gravity once a limit is reached). Higher Ki than the
+// tracking PID so the integrator builds up fast enough to absorb the
+// constant gravity load and keep the residual drop in the few-mm range
+// on brake engagement (bench-tuned).
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_kp{10.0f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_ki{3.0f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_kd{0.f};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative>
+    motor_lift_brake_speed_pid_integral_limit{
+        static_cast<float>(etl::numeric_limits<int16_t>::max())};
+
 // Motor lift threshold
 constexpr float motor_lift_threshold = 1.0;
 
@@ -138,6 +153,16 @@ inline cogip::pid::PIDParameters motor_lift_speed_pid_params(motor_lift_speed_pi
 /// @brief Motor Lift speed PID controller
 inline cogip::pid::PID motor_lift_speed_pid(motor_lift_speed_pid_params);
 
+/// @brief Motor Lift brake speed PID parameters (dedicated to the brake chain)
+inline cogip::pid::PIDParameters
+    motor_lift_brake_speed_pid_params(motor_lift_brake_speed_pid_kp, motor_lift_brake_speed_pid_ki,
+                                      motor_lift_brake_speed_pid_kd,
+                                      motor_lift_brake_speed_pid_integral_limit);
+
+/// @brief Motor Lift brake speed PID controller (separate instance so its
+/// integrator state does not interfere with the tracking PID).
+inline cogip::pid::PID motor_lift_brake_speed_pid(motor_lift_brake_speed_pid_params);
+
 /// @brief Motor Lift MotorPoseFilterParameters
 static cogip::motion_control::MotorPoseFilterParameters
     motor_lift_pose_filter_parameters(motor_lift_threshold,
@@ -155,6 +180,10 @@ static cogip::motion_control::SpeedFilterParameters motor_lift_speed_filter_para
 /// @brief Motor Lift SpeedPIDControllerParameters.
 static cogip::motion_control::SpeedPIDControllerParameters
     motor_lift_speed_pid_parameters(&motor_lift_speed_pid);
+
+/// @brief Motor Lift brake SpeedPIDControllerParameters (dedicated to brake chain).
+static cogip::motion_control::SpeedPIDControllerParameters
+    motor_lift_brake_speed_pid_parameters(&motor_lift_brake_speed_pid);
 
 /// @brief Motor Lift ProfileTrackerControllerParameters (for DUALPID_TRACKER mode).
 /// @details Defines the trapezoidal velocity profile limits for smooth motion control.
@@ -239,6 +268,7 @@ make_lift_motor_params(cogip::actuators::Enum actuator_id, bool use_tracker_chai
         /* speed_limit_filter_params    */ &motor_lift_speed_limit_parameters,
         /* deceleration_filter_params   */ &motor_lift_deceleration_filter_parameters,
         /* anti_blocking_params         */ &motor_lift_anti_blocking_parameters,
+        /* brake_speed_controller_params*/ motor_lift_brake_speed_pid_parameters,
     };
 }
 

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -143,23 +143,39 @@ void Lift::at_lower_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.lower_limit_switch_pin)) {
         LOG_INFO("Lower limit switch pressed\n");
-        set_current_distance(params_.lower_limit_mm);
-        // If the current command targets the lower limit, the switch
-        // pressing IS the definitive "reached" signal. Emit it before
-        // disable() cuts the engine, otherwise the engine will never
-        // run another tick to fire pose_reached_cb and the host would
-        // never hear that the target was reached.
-        if (last_command_ == params_.lower_limit_mm) {
-            on_state_change(motion_control::target_pose_status_t::reached);
+        // Always wake init() out of its homing wait, even on a spurious
+        // press, so the homing path never wedges on a glitch. Safe to
+        // call when no init is in flight: unlocking an already-unlocked
+        // RIOT mutex is a no-op.
+        mutex_unlock(&initializing_);
+
+        // Decide based on motion direction, not on the exact target. A
+        // belt slip can overshoot us through the lower switch even when
+        // the requested command was somewhere above lower_limit_mm: in
+        // that case the switch press is still a genuine end-of-travel
+        // event we must honor, not an unrelated glitch.
+        const float current = get_current_distance();
+        const bool moving_up = static_cast<float>(last_command_) > current;
+        if (moving_up) {
+            // Switch press while we are ascending: spurious press
+            // (mechanical bounce, manual interaction). Touching the
+            // motor here would silently freeze the in-flight upward
+            // motion.
+            LOG_WARNING("Lower limit pressed while ascending (cur=%.1f, "
+                        "last_cmd=%" PRIi32 "), ignoring\n",
+                        static_cast<double>(current), last_command_);
+            return;
         }
+        set_current_distance(params_.lower_limit_mm);
+        // The switch pressing IS the definitive "reached" signal. Emit
+        // it before disable() cuts the engine, otherwise the engine
+        // will never run another tick to fire pose_reached_cb and the
+        // host would never hear that the target was reached.
+        on_state_change(motion_control::target_pose_status_t::reached);
         disable();
         // Invalidate last_command_ so the next actuate() with the same
         // target is not skipped and can re-enable the motor.
         last_command_ = INT32_MIN;
-        // Wake init() out of its homing wait. Safe to call when no init
-        // is in flight: unlocking an already-unlocked RIOT mutex is a
-        // no-op.
-        mutex_unlock(&initializing_);
     } else {
         LOG_INFO("Lower limit switch released\n");
     }
@@ -170,15 +186,30 @@ void Lift::at_upper_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.upper_limit_switch_pin)) {
         LOG_INFO("Upper limit switch pressed\n");
-        motor_engine_.set_timeout_enable(false);
-        // If the current command targets the upper limit, the switch
-        // pressing IS the definitive "reached" signal. Emit it now: the
-        // brake chain takes over and does not drive the pose loop, so
-        // MotorEngine::process_outputs() cannot fire pose_reached_cb on
-        // its own from here on.
-        if (last_command_ == params_.upper_limit_mm) {
-            on_state_change(motion_control::target_pose_status_t::reached);
+
+        // Decide based on motion direction, not on the exact target. A
+        // belt slip can overshoot us into the upper switch even when
+        // the requested command was below upper_limit_mm: in that case
+        // the switch press is still a genuine end-of-travel event we
+        // must honor (mechanical safety wins).
+        const float current = get_current_distance();
+        const bool moving_down = static_cast<float>(last_command_) < current;
+        if (moving_down) {
+            // Switch press while we are descending: spurious
+            // (mechanical bounce, manual interaction). Latching the
+            // brake chain here would silently freeze the in-flight
+            // downward motion.
+            LOG_WARNING("Upper limit pressed while descending (cur=%.1f, "
+                        "last_cmd=%" PRIi32 "), ignoring\n",
+                        static_cast<double>(current), last_command_);
+            return;
         }
+        motor_engine_.set_timeout_enable(false);
+        // The switch pressing IS the definitive "reached" signal. Emit
+        // it now: the brake chain takes over and does not drive the
+        // pose loop, so MotorEngine::process_outputs() cannot fire
+        // pose_reached_cb on its own from here on.
+        on_state_change(motion_control::target_pose_status_t::reached);
         // Latch the engine brake chain: the zero-speed-order + speed PID
         // chain actively drives the motor toward zero speed, holding the
         // lift against gravity without needing the full pose loop.

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -6,6 +6,7 @@
 #include "log.h"
 #include <inttypes.h>
 #include <periph/gpio.h>
+#include <ztimer.h>
 
 #include "actuator/Lift.hpp"
 #include "actuator/LiftsLimitSwitchesManager.hpp"
@@ -46,7 +47,6 @@ void Lift::init()
     }
 
     // Homing: move down to calibrate zero position
-    initializing_ = true;
     set_target_speed_percent(params_.init_speed_percentage);
 
     int lower_state = gpio_read(params_.lower_limit_switch_pin);
@@ -55,17 +55,33 @@ void Lift::init()
     constexpr uint32_t init_timeout_ms = 2000;
 
     if (!lower_state) {
+        // Lock the homing mutex up front; at_lower_limit() unlocks it on the
+        // rising edge of the lower switch, so the wait below exits the
+        // moment the descent is physically done.
+        mutex_lock(&initializing_);
+
         // Force current position to upper limit so the motor moves down
         set_current_distance(params_.upper_limit_mm);
         LOG_INFO("Moving to lower limit (%d mm)...\n", static_cast<int>(params_.lower_limit_mm));
         actuate_timeout(params_.lower_limit_mm, init_timeout_ms);
-        ztimer_sleep(ZTIMER_MSEC, init_timeout_ms);
-        // If lower limit was not reached, disable motor to prevent
-        // violent movement on power restore (e.g. after emergency stop)
-        if (!gpio_read(params_.lower_limit_switch_pin)) {
+
+        // Block until the ISR signals that the switch was hit, with a hard
+        // cap of init_timeout_ms so a stuck lift never wedges the CAN
+        // handler thread for longer than the homing timeout.
+        int wait_ret = ztimer_mutex_lock_timeout(ZTIMER_MSEC, &initializing_, init_timeout_ms);
+        if (wait_ret < 0) {
+            // Lower limit was not reached: cut the motor to prevent
+            // violent movement on power restore (e.g. after emergency
+            // stop). initializing_ is still locked from the up-front
+            // mutex_lock; release it below.
             LOG_INFO("Init timeout, disabling motor\n");
             disable();
         }
+        // On success, the ISR's mutex_unlock + our lock_timeout dance left
+        // the mutex re-locked on our side; on timeout, it is still locked
+        // from the up-front lock. Either way, leave it unlocked so the
+        // next init() can lock it again.
+        mutex_unlock(&initializing_);
         LOG_INFO("Lower limit reached or timeout\n");
     } else {
         LOG_INFO("Already at lower limit, setting distance to %d mm\n",
@@ -73,7 +89,6 @@ void Lift::init()
         set_current_distance(params_.lower_limit_mm);
     }
 
-    initializing_ = false;
     LOG_INFO("Lift init complete\n");
 }
 
@@ -141,6 +156,10 @@ void Lift::at_lower_limit()
         // Invalidate last_command_ so the next actuate() with the same
         // target is not skipped and can re-enable the motor.
         last_command_ = INT32_MIN;
+        // Wake init() out of its homing wait. Safe to call when no init
+        // is in flight: unlocking an already-unlocked RIOT mutex is a
+        // no-op.
+        mutex_unlock(&initializing_);
     } else {
         LOG_INFO("Lower limit switch released\n");
     }

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -143,23 +143,40 @@ void Lift::at_lower_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.lower_limit_switch_pin)) {
         LOG_INFO("Lower limit switch pressed\n");
+        // Always wake init() out of its homing wait, even on a spurious
+        // press, so the homing path never wedges on a glitch. Safe to
+        // call when no init is in flight: unlocking an already-unlocked
+        // RIOT mutex is a no-op.
+        mutex_unlock(&initializing_);
+
+        // The switch pressing is a definitive mechanical reference: zero
+        // the odometer against it unconditionally. This corrects any
+        // drift from controller overshoot, belt slip, or accumulated
+        // encoder error, regardless of what the host had asked for.
         set_current_distance(params_.lower_limit_mm);
-        // If the current command targets the lower limit, the switch
-        // pressing IS the definitive "reached" signal. Emit it before
-        // disable() cuts the engine, otherwise the engine will never
-        // run another tick to fire pose_reached_cb and the host would
-        // never hear that the target was reached.
-        if (last_command_ == params_.lower_limit_mm) {
-            on_state_change(motion_control::target_pose_status_t::reached);
+
+        // We just zeroed current to lower_limit_mm, so the test
+        // collapses to a pure intent check on last_command_: if the
+        // host commanded a target above the switch, the press is a
+        // glitch on our way up (mechanical bounce on departure) or a
+        // belt-slip detection, and we must not interrupt the motion.
+        // Otherwise the host wanted to be at the switch and we treat
+        // the press as genuine end-of-travel.
+        if (last_command_ > params_.lower_limit_mm) {
+            LOG_INFO("Lower switch pressed with target above (last_cmd=%" PRIi32 "), resync only\n",
+                     last_command_);
+            return;
         }
+
+        // The switch pressing IS the definitive "reached" signal. Emit
+        // it before disable() cuts the engine, otherwise the engine
+        // will never run another tick to fire pose_reached_cb and the
+        // host would never hear that the target was reached.
+        on_state_change(motion_control::target_pose_status_t::reached);
         disable();
         // Invalidate last_command_ so the next actuate() with the same
         // target is not skipped and can re-enable the motor.
         last_command_ = INT32_MIN;
-        // Wake init() out of its homing wait. Safe to call when no init
-        // is in flight: unlocking an already-unlocked RIOT mutex is a
-        // no-op.
-        mutex_unlock(&initializing_);
     } else {
         LOG_INFO("Lower limit switch released\n");
     }
@@ -170,15 +187,30 @@ void Lift::at_upper_limit()
     // Only react when switch is pressed (reads 1 with active-high logic)
     if (gpio_read(params_.upper_limit_switch_pin)) {
         LOG_INFO("Upper limit switch pressed\n");
-        motor_engine_.set_timeout_enable(false);
-        // If the current command targets the upper limit, the switch
-        // pressing IS the definitive "reached" signal. Emit it now: the
-        // brake chain takes over and does not drive the pose loop, so
-        // MotorEngine::process_outputs() cannot fire pose_reached_cb on
-        // its own from here on.
-        if (last_command_ == params_.upper_limit_mm) {
-            on_state_change(motion_control::target_pose_status_t::reached);
+
+        // Decide based on motion direction, not on the exact target. A
+        // belt slip can overshoot us into the upper switch even when
+        // the requested command was below upper_limit_mm: in that case
+        // the switch press is still a genuine end-of-travel event we
+        // must honor (mechanical safety wins).
+        const float current = get_current_distance();
+        const bool moving_down = static_cast<float>(last_command_) < current;
+        if (moving_down) {
+            // Switch press while we are descending: spurious
+            // (mechanical bounce, manual interaction). Latching the
+            // brake chain here would silently freeze the in-flight
+            // downward motion.
+            LOG_WARNING("Upper limit pressed while descending (cur=%.1f, "
+                        "last_cmd=%" PRIi32 "), ignoring\n",
+                        static_cast<double>(current), last_command_);
+            return;
         }
+        motor_engine_.set_timeout_enable(false);
+        // The switch pressing IS the definitive "reached" signal. Emit
+        // it now: the brake chain takes over and does not drive the
+        // pose loop, so MotorEngine::process_outputs() cannot fire
+        // pose_reached_cb on its own from here on.
+        on_state_change(motion_control::target_pose_status_t::reached);
         // Latch the engine brake chain: the zero-speed-order + speed PID
         // chain actively drives the motor toward zero speed, holding the
         // lift against gravity without needing the full pose loop.

--- a/lib/actuator/Motor.cpp
+++ b/lib/actuator/Motor.cpp
@@ -57,10 +57,13 @@ Motor::Motor(const MotorParameters& motor_parameters, MotorControlMode mode)
                                 motor_parameters.speed_controller_parameters),
       tracker_motor_distance_filter_(actuators::motor_tracker_pose_filter_io_keys,
                                      motor_parameters.motor_pose_filter_parameters),
-      // Brake chain: zero speed_order + dedicated speed PID
+      // Brake chain: zero speed_order + dedicated speed PID. Separate PID
+      // instance from the tracking loop so the static-hold gains (typically a
+      // higher Ki to counter constant disturbances like gravity) do not couple
+      // their integrator state with trajectory tracking.
       brake_zero_speed_order_controller_({{"speed_order", 0.0f}}),
       brake_speed_controller_(actuators::motor_speed_pid_io_keys,
-                              motor_parameters.speed_controller_parameters),
+                              motor_parameters.brake_speed_controller_parameters),
       // Motor engine
       motor_engine_(motor_parameters.motor, motor_parameters.odometer,
                     motor_parameters.engine_thread_period_ms)

--- a/lib/actuator/include/actuator/Lift.hpp
+++ b/lib/actuator/include/actuator/Lift.hpp
@@ -14,6 +14,9 @@
 // System includes
 #include <climits>
 
+// RIOT includes
+#include "mutex.h"
+
 // Project includes
 #include "actuator/LiftParameters.hpp"
 #include "actuator/Motor.hpp"
@@ -57,8 +60,14 @@ class Lift : public Motor
     /// Reference to the static configuration parameters for this lift actuator.
     const LiftParameters& params_;
 
-    /// True while the homing sequence is running (init only).
-    bool initializing_ = false;
+    /// @brief Synchronisation primitive for the homing sequence.
+    /// @details Locked by init() while waiting for the descent to physically
+    ///          reach the lower limit. at_lower_limit() unlocks it on the
+    ///          rising edge of the lower switch, so init() exits its wait
+    ///          the moment the homing is done instead of always sleeping
+    ///          for the full timeout. RIOT mutexes are unlock-no-op when
+    ///          unlocked, so a stray ISR firing outside an init is safe.
+    mutex_t initializing_ = MUTEX_INIT;
 
     /// Last commanded position (after clamping), used to skip redundant actuate calls.
     int32_t last_command_ = INT32_MIN;

--- a/lib/actuator/include/actuator/MotorParameters.hpp
+++ b/lib/actuator/include/actuator/MotorParameters.hpp
@@ -118,6 +118,14 @@ struct MotorParameters
     /// @details If non-null, an AntiBlockingController is appended after SpeedPID
     ///          to detect motor stalls and set pose_reached to blocked.
     motion_control::AntiBlockingControllerParameters* anti_blocking_parameters = nullptr;
+
+    /// @brief Parameters for the SpeedPIDController used by the brake chain.
+    /// @details The brake chain (ZeroSpeedOrder + SpeedPID) actively holds the
+    ///          motor against a constant disturbance (e.g. gravity on a lift).
+    ///          Must use a PID instance distinct from `speed_controller_parameters`
+    ///          so the static-hold gains can be tuned independently from the
+    ///          tracking gains and the integrator states do not interfere.
+    motion_control::SpeedPIDControllerParameters& brake_speed_controller_parameters;
 };
 
 } // namespace positional_actuators

--- a/platforms/pf-robot-motors/pf_actuators.cpp
+++ b/platforms/pf-robot-motors/pf_actuators.cpp
@@ -76,9 +76,9 @@ static void _handle_command(cogip::canpb::ReadBuffer& buffer)
                 positional_actuators::get(id).actuate(pb_positional_actuator_command.command());
             }
 
-            LOG_INFO("Target distance: %" PRIi32, pb_positional_actuator_command.command());
-            LOG_INFO("Target speed: %" PRIi32, pb_positional_actuator_command.speed());
-            LOG_INFO("Timeout: %" PRIi32, timeout_ms);
+            LOG_INFO("Target distance: %" PRIi32 "\n", pb_positional_actuator_command.command());
+            LOG_INFO("Target speed: %" PRIi32 "\n", pb_positional_actuator_command.speed());
+            LOG_INFO("Timeout: %" PRIi32 "\n", timeout_ms);
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Wake homing wait on switch hit**: replace the unconditional 2 s `ztimer_sleep` in `Lift::init()` with a mutex acquired up front and released by `at_lower_limit()` on the rising edge. The init returns the moment homing is physically done; the CAN handler thread no longer wedges on every init.
- **Newline on `_handle_command` logs**: add the missing trailing `\n` on the three logs at the tail of `_handle_command` so concurrent ISR notices stop being concatenated to them in the `cogip-mcu-logger` stream.
- **Direction-gated limit-switch handling**: only ignore a switch press when the lift is genuinely above (resp. below) the switch and moving away from it. Overshoot through a switch is still honoured as a genuine end-of-travel; bounces during the opposite-direction motion no longer freeze an in-flight command.
- **Dedicated brake PID**: split the brake chain off the tracking PID with its own `PIDParameters` and `PID` instance. Values match the tracking gains, so behaviour is unchanged out of the box; the integrator state is now isolated, unblocking future independent tuning of the brake against gravity without touching trajectory tracking.