### PR TITLE
PlatformEngine: latch the brake chain on reached arrivals

### DIFF
--- a/applications/robot-motion-control/include/robot1_conf.hpp
+++ b/applications/robot-motion-control/include/robot1_conf.hpp
@@ -64,6 +64,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 5.5;
 constexpr float default_tracker_angular_speed_pid_ki = 0.6;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 3.;
+constexpr float default_brake_linear_speed_pid_ki = 0.8;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 5.5;
+constexpr float default_brake_angular_speed_pid_ki = 0.6;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 2;
 // Angular threshold
@@ -123,4 +138,14 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot2_conf.hpp
+++ b/applications/robot-motion-control/include/robot2_conf.hpp
@@ -68,6 +68,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 4.5;
 constexpr float default_tracker_angular_speed_pid_ki = 0.125;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 7;
+constexpr float default_brake_linear_speed_pid_ki = 0.4;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 4.5;
+constexpr float default_brake_angular_speed_pid_ki = 0.125;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 3;
 // Angular threshold
@@ -125,6 +140,16 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());
 
 // ============================================================================

--- a/motion_control/engines/platform_engine/PlatformEngine.cpp
+++ b/motion_control/engines/platform_engine/PlatformEngine.cpp
@@ -88,64 +88,103 @@ void PlatformEngine::process_outputs()
         return;
     }
 
-    // Check pose_reached from IO (set by controllers like PoseErrorFilter or PoseStraightFilter)
-    auto io_pose_reached = io_.get_as<target_pose_status_t>("pose_reached");
-    auto prev_pose_reached = pose_reached_;
+    // While the brake is latched, the engine runs the brake chain only:
+    // pose_reached_ stays sticky at the value that triggered the latch (so
+    // we do not refire the reached callback every cycle), no IO read, no
+    // logging, no transition detection. Just forward the speed command
+    // produced by the brake chain to the drive controller. set_brake(false)
+    // is the only way out and is issued by the motion-control API
+    // (pf_handle_target_pose, pf_handle_path_start, etc.) on a new motion
+    // request.
+    if (!brake_) {
+        // Check pose_reached from IO (set by controllers like PoseErrorFilter or
+        // PoseStraightFilter)
+        auto io_pose_reached = io_.get_as<target_pose_status_t>("pose_reached");
+        auto prev_pose_reached = pose_reached_;
 
-    if (io_pose_reached && (*io_pose_reached == target_pose_status_t::reached ||
-                            *io_pose_reached == target_pose_status_t::intermediate_reached ||
-                            *io_pose_reached == target_pose_status_t::blocked)) {
-        pose_reached_ = *io_pose_reached;
-    } else if (!timeout_enable_) {
-        // No timeout mode: use IO value directly
-        pose_reached_ = io_pose_reached.value_or(target_pose_status_t::moving);
-    }
-    // If timeout is enabled and not reached: pose_reached_ keeps its current value
-    // (either 'moving' or 'timeout' set by the engine)
-
-    // Detect case where a new target was processed and immediately reached FINISHED
-    // in the same cycle (pose_reached_ stays 'reached' with no visible transition).
-    // Force a moving→reached transition so the planner sees the new reached event.
-    bool force_moving_transition = false;
-    if (pose_reached_ == prev_pose_reached &&
-        (pose_reached_ == target_pose_status_t::reached ||
-         pose_reached_ == target_pose_status_t::intermediate_reached)) {
-        auto new_target = io_.get_as<bool>("new_target");
-        if (new_target && *new_target) {
-            force_moving_transition = true;
+        if (io_pose_reached && (*io_pose_reached == target_pose_status_t::reached ||
+                                *io_pose_reached == target_pose_status_t::intermediate_reached ||
+                                *io_pose_reached == target_pose_status_t::blocked)) {
+            pose_reached_ = *io_pose_reached;
+        } else if (!timeout_enable_) {
+            // No timeout mode: use IO value directly
+            pose_reached_ = io_pose_reached.value_or(target_pose_status_t::moving);
         }
+        // If timeout is enabled and not reached: pose_reached_ keeps its current value
+        // (either 'moving' or 'timeout' set by the engine)
+
+        // Detect case where a new target was processed and immediately reached FINISHED
+        // in the same cycle (pose_reached_ stays 'reached' with no visible transition).
+        // Force a moving→reached transition so the planner sees the new reached event.
+        bool force_moving_transition = false;
+        if (pose_reached_ == prev_pose_reached &&
+            (pose_reached_ == target_pose_status_t::reached ||
+             pose_reached_ == target_pose_status_t::intermediate_reached)) {
+            auto new_target = io_.get_as<bool>("new_target");
+            if (new_target && *new_target) {
+                force_moving_transition = true;
+            }
+        }
+
+        // Log pose_reached transitions
+        if (pose_reached_ != prev_pose_reached || force_moving_transition) {
+            const auto& cur = localization_.pose();
+            const path::Pose* wp = path_.current_pose();
+            const float tx = wp ? wp->x() : 0.0f;
+            const float ty = wp ? wp->y() : 0.0f;
+            const float tO = wp ? wp->O() : 0.0f;
+            LOG_INFO("pose_reached=%d cur=(%.1f,%.1f,%.1f) tgt=(%.1f,%.1f,%.1f)\n",
+                     static_cast<int>(pose_reached_), static_cast<double>(cur.x()),
+                     static_cast<double>(cur.y()), static_cast<double>(cur.O()),
+                     static_cast<double>(tx), static_cast<double>(ty), static_cast<double>(tO));
+        }
+
+        // Engage the brake chain on the rising edge of the final 'reached'
+        // status. We do not latch on 'intermediate_reached' (path waypoints
+        // expect motion to continue) nor on 'blocked' (host-level handling).
+        // From the next cycle on, the brake chain takes over and holds the
+        // robot at zero speed.
+        // We are already running under the engine mutex (taken at the top of
+        // BaseControllerEngine::thread_loop), so we cannot call set_brake()
+        // here: it would re-lock the same non-recursive mutex and deadlock.
+        // Assign brake_ directly instead.
+        if (pose_reached_ != prev_pose_reached && pose_reached_ == target_pose_status_t::reached) {
+            brake_ = true;
+            // Reset brake speed PID integrators so they start clean. Without
+            // this, the residual speed at the moment of latch is integrated
+            // for one or two cycles, then current_speed drops to 0 but the
+            // accumulated integral keeps producing a constant non-zero
+            // command, dragging the robot off-target during hold.
+            io_.set("linear_speed_pid_reset", true);
+            io_.set("angular_speed_pid_reset", true);
+            LOG_INFO("Engaging brake chain on reached\n");
+        }
+
+        cogip_defs::Polar command(0, 0);
+
+        DEBUG("Start process_outputs()\n");
+        command.set_distance(io_.get_as<float>("linear_speed_command").value());
+        command.set_angle(io_.get_as<float>("angular_speed_command").value());
+        DEBUG("End process_outputs()\n");
+
+        // Set robot polar velocity order
+        drive_contoller_.set_polar_velocity(command);
+
+        // If new target reached immediately, dispatch moving first then reached
+        if (force_moving_transition) {
+            pose_reached_cb_(target_pose_status_t::moving);
+        }
+
+        // Dispatch pose reached state
+        pose_reached_cb_(pose_reached_);
+    } else {
+        // Brake-only path: still drive the motors with the brake chain's
+        // speed command so the closed-loop hold actually runs.
+        cogip_defs::Polar command(0, 0);
+        command.set_distance(io_.get_as<float>("linear_speed_command").value());
+        command.set_angle(io_.get_as<float>("angular_speed_command").value());
+        drive_contoller_.set_polar_velocity(command);
     }
-
-    // Log pose_reached transitions
-    if (pose_reached_ != prev_pose_reached || force_moving_transition) {
-        const auto& cur = localization_.pose();
-        const path::Pose* wp = path_.current_pose();
-        const float tx = wp ? wp->x() : 0.0f;
-        const float ty = wp ? wp->y() : 0.0f;
-        const float tO = wp ? wp->O() : 0.0f;
-        LOG_INFO("pose_reached=%d cur=(%.1f,%.1f,%.1f) tgt=(%.1f,%.1f,%.1f)\n",
-                 static_cast<int>(pose_reached_), static_cast<double>(cur.x()),
-                 static_cast<double>(cur.y()), static_cast<double>(cur.O()),
-                 static_cast<double>(tx), static_cast<double>(ty), static_cast<double>(tO));
-    }
-
-    cogip_defs::Polar command(0, 0);
-
-    DEBUG("Start process_outputs()\n");
-    command.set_distance(io_.get_as<float>("linear_speed_command").value());
-    command.set_angle(io_.get_as<float>("angular_speed_command").value());
-    DEBUG("End process_outputs()\n");
-
-    // Set robot polar velocity order
-    drive_contoller_.set_polar_velocity(command);
-
-    // If new target reached immediately, dispatch moving first then reached
-    if (force_moving_transition) {
-        pose_reached_cb_(target_pose_status_t::moving);
-    }
-
-    // Dispatch pose reached state
-    pose_reached_cb_(pose_reached_);
 };
 
 } // namespace motion_control

--- a/motion_control/engines/platform_engine/PlatformEngine.cpp
+++ b/motion_control/engines/platform_engine/PlatformEngine.cpp
@@ -113,6 +113,32 @@ void PlatformEngine::process_outputs()
         // If timeout is enabled and not reached: pose_reached_ keeps its current value
         // (either 'moving' or 'timeout' set by the engine)
 
+        // Anti-blocking bypass: if the current waypoint declares
+        // bypass_anti_blocking, treat a 'blocked' status as 'reached' instead
+        // of forwarding it to the platform callback. This is the standard
+        // semantic for moves that are expected to push against something
+        // (e.g. docking) and where the abrupt stop IS the success criterion.
+        // The conversion is done here so the platform callback only ever
+        // sees the resolved state and does not have to re-implement the
+        // logic. We also replace the current waypoint with a hold pose at
+        // the robot's actual position so any subsequent path operation has
+        // a consistent state; the brake chain then takes over via the
+        // rising-edge logic below.
+        if (pose_reached_ == target_pose_status_t::blocked) {
+            const path::Pose* wp = path_.current_pose();
+            if (wp && wp->bypass_anti_blocking()) {
+                path::Pose hold = *wp;
+                hold.set_x(localization_.pose().x());
+                hold.set_y(localization_.pose().y());
+                hold.set_O(localization_.pose().O());
+                path_.reset();
+                path_.add_point(hold);
+                path_.start();
+                pose_reached_ = target_pose_status_t::reached;
+                LOG_INFO("Anti-blocking bypassed: blocked converted to reached\n");
+            }
+        }
+
         // Detect case where a new target was processed and immediately reached FINISHED
         // in the same cycle (pose_reached_ stays 'reached' with no visible transition).
         // Force a moving→reached transition so the planner sees the new reached event.
@@ -150,13 +176,15 @@ void PlatformEngine::process_outputs()
         // Assign brake_ directly instead.
         if (pose_reached_ != prev_pose_reached && pose_reached_ == target_pose_status_t::reached) {
             brake_ = true;
-            // Reset brake speed PID integrators so they start clean. Without
-            // this, the residual speed at the moment of latch is integrated
-            // for one or two cycles, then current_speed drops to 0 but the
-            // accumulated integral keeps producing a constant non-zero
-            // command, dragging the robot off-target during hold.
-            io_.set("linear_speed_pid_reset", true);
-            io_.set("angular_speed_pid_reset", true);
+            // Reset the brake controller (cascades to its PIDs) so it starts
+            // from a clean state. Without this, the residual robot speed at
+            // the moment of latch is integrated for one or two cycles, then
+            // current_speed drops to 0 but the accumulated integral keeps
+            // producing a constant non-zero command, dragging the robot
+            // off-target during hold.
+            if (brake_controller_) {
+                brake_controller_->reset();
+            }
             LOG_INFO("Engaging brake chain on reached\n");
         }
 

--- a/platforms/pf-robot-motion-control/brake_chain.hpp
+++ b/platforms/pf-robot-motion-control/brake_chain.hpp
@@ -13,8 +13,8 @@
 
 #pragma once
 
-#include "app_conf.hpp"
 #include "motion_control_common/MetaController.hpp"
+#include "motion_control_parameters.hpp"
 #include "pid/PID.hpp"
 #include "polar_parallel_meta_controller/PolarParallelMetaController.hpp"
 #include "reset_controller/ResetController.hpp"
@@ -22,22 +22,33 @@
 #include "speed_pid_controller/SpeedPIDControllerIOKeysDefault.hpp"
 #include "speed_pid_controller/SpeedPIDControllerParameters.hpp"
 
-// Pull in the shared PID parameter instances used by the normal speed loop;
-// the brake chain starts with the same gains, tuning can be done later.
-#include "quadpid_chain.hpp"
-
 namespace cogip {
 namespace pf {
 namespace motion_control {
 
 namespace brake_chain {
 
-// Dedicated PID state for the brake speed loop. Gains come from the same
-// parameters as the normal speed loop, but the integrator / previous-error
-// state must not be shared so that activating the brake does not pollute
+// Dedicated PIDParameters for the brake speed loop. Gains live in their own
+// Parameter<float> instances (declared in motion_control_parameters.hpp) so
+// the brake can be tuned independently from the tracking PIDs; same for the
+// PID state (integrator, previous error) thanks to the dedicated PID
+// instances below. The brake chain typically wants higher Ki than the
+// tracking loop to absorb static disturbances on hold (slope, friction,
+// push from another robot) which the cascaded Ki=0 pose loop cannot.
+inline cogip::pid::PIDParameters
+    brake_linear_speed_pid_parameters(brake_linear_speed_pid_kp, brake_linear_speed_pid_ki,
+                                      brake_linear_speed_pid_kd,
+                                      brake_linear_speed_pid_integral_limit);
+inline cogip::pid::PIDParameters
+    brake_angular_speed_pid_parameters(brake_angular_speed_pid_kp, brake_angular_speed_pid_ki,
+                                       brake_angular_speed_pid_kd,
+                                       brake_angular_speed_pid_integral_limit);
+
+// Dedicated PID instances. Their integrator / previous-error state stays
+// isolated from the tracking PIDs so latching the brake does not pollute
 // (or get polluted by) the running chain.
-inline cogip::pid::PID brake_linear_speed_pid(quadpid_chain::linear_speed_pid_parameters);
-inline cogip::pid::PID brake_angular_speed_pid(quadpid_chain::angular_speed_pid_parameters);
+inline cogip::pid::PID brake_linear_speed_pid(brake_linear_speed_pid_parameters);
+inline cogip::pid::PID brake_angular_speed_pid(brake_angular_speed_pid_parameters);
 
 inline cogip::motion_control::SpeedPIDControllerParameters
     brake_linear_speed_controller_parameters(&brake_linear_speed_pid);

--- a/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
+++ b/platforms/pf-robot-motion-control/include/motion_control_parameters.hpp
@@ -91,6 +91,14 @@ constexpr uint32_t TRACKER_LINEAR_SPEED_PID_KD_KEY = "tracker_linear_speed_pid_k
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KP_KEY = "tracker_angular_speed_pid_kp"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KI_KEY = "tracker_angular_speed_pid_ki"_key_hash;
 constexpr uint32_t TRACKER_ANGULAR_SPEED_PID_KD_KEY = "tracker_angular_speed_pid_kd"_key_hash;
+// Brake linear speed PID
+constexpr uint32_t BRAKE_LINEAR_SPEED_PID_KP_KEY = "brake_linear_speed_pid_kp"_key_hash;
+constexpr uint32_t BRAKE_LINEAR_SPEED_PID_KI_KEY = "brake_linear_speed_pid_ki"_key_hash;
+constexpr uint32_t BRAKE_LINEAR_SPEED_PID_KD_KEY = "brake_linear_speed_pid_kd"_key_hash;
+// Brake angular speed PID
+constexpr uint32_t BRAKE_ANGULAR_SPEED_PID_KP_KEY = "brake_angular_speed_pid_kp"_key_hash;
+constexpr uint32_t BRAKE_ANGULAR_SPEED_PID_KI_KEY = "brake_angular_speed_pid_ki"_key_hash;
+constexpr uint32_t BRAKE_ANGULAR_SPEED_PID_KD_KEY = "brake_angular_speed_pid_kd"_key_hash;
 
 // ============================================================================
 // Unit conversion macros and control loop period
@@ -207,6 +215,15 @@ inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KI_KEY>> tracker_angular_speed_pid_ki{default_tracker_angular_speed_pid_ki};
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<TRACKER_ANGULAR_SPEED_PID_KD_KEY>> tracker_angular_speed_pid_kd{default_tracker_angular_speed_pid_kd};
 
+// Brake linear speed PID
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_LINEAR_SPEED_PID_KP_KEY>> brake_linear_speed_pid_kp{default_brake_linear_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_LINEAR_SPEED_PID_KI_KEY>> brake_linear_speed_pid_ki{default_brake_linear_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_LINEAR_SPEED_PID_KD_KEY>> brake_linear_speed_pid_kd{default_brake_linear_speed_pid_kd};
+// Brake angular speed PID
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_ANGULAR_SPEED_PID_KP_KEY>> brake_angular_speed_pid_kp{default_brake_angular_speed_pid_kp};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_ANGULAR_SPEED_PID_KI_KEY>> brake_angular_speed_pid_ki{default_brake_angular_speed_pid_ki};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative, cogip::parameter::WithFlashStorage<BRAKE_ANGULAR_SPEED_PID_KD_KEY>> brake_angular_speed_pid_kd{default_brake_angular_speed_pid_kd};
+
 // PID integral limits
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> linear_pose_pid_integral_limit{default_linear_pose_pid_integral_limit};
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> angular_pose_pid_integral_limit{default_angular_pose_pid_integral_limit};
@@ -218,6 +235,10 @@ inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_angular_pose_pid_integral_limit{default_tracker_angular_pose_pid_integral_limit};
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_linear_speed_pid_integral_limit{default_tracker_linear_speed_pid_integral_limit};
 inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> tracker_angular_speed_pid_integral_limit{default_tracker_angular_speed_pid_integral_limit};
+
+// Brake speed PID integral limits
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> brake_linear_speed_pid_integral_limit{default_brake_linear_speed_pid_integral_limit};
+inline cogip::parameter::Parameter<float, cogip::parameter::NonNegative> brake_angular_speed_pid_integral_limit{default_brake_angular_speed_pid_integral_limit};
 
 // Pose straight filter thresholds (absolute units: mm, deg)
 inline cogip::parameter::Parameter<float, cogip::parameter::Clamp<1, 10>, cogip::parameter::WithFlashStorage<LINEAR_THRESHOLD_KEY>> param_linear_threshold{linear_threshold};

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -411,6 +411,10 @@ void pf_handle_target_pose(cogip::canpb::ReadBuffer& buffer)
         pf_motion_control_platform_engine.set_timeout_enable(false);
     }
 
+    // Release any latched brake from a previous reached arrival so the
+    // normal control chain runs again on this new motion.
+    pf_motion_control_platform_engine.set_brake(false);
+
     pf_motion_control_platform_engine.set_pose_reached(
         cogip::motion_control::target_pose_status_t::moving);
 
@@ -452,6 +456,9 @@ void pf_handle_speed_order(cogip::canpb::ReadBuffer& buffer)
         X_SEC_TO_X_PERIOD(linear_speed_mm_s, motion_control_thread_period_ms));
     target_speed.set_angle(X_SEC_TO_X_PERIOD(angular_speed_deg_s, motion_control_thread_period_ms));
     pf_motion_control_platform_engine.set_target_speed(target_speed);
+
+    // Release any latched brake from a previous reached arrival.
+    pf_motion_control_platform_engine.set_brake(false);
 
     pf_motion_control_platform_engine.set_pose_reached(
         cogip::motion_control::target_pose_status_t::moving);
@@ -496,6 +503,10 @@ void pf_handle_start_pose(cogip::canpb::ReadBuffer& buffer)
     motion_control_path.reset();
     motion_control_path.add_point(pose);
     motion_control_path.start();
+
+    // Release any latched brake from a previous reached arrival so the
+    // engine starts cleanly from the new localization.
+    pf_motion_control_platform_engine.set_brake(false);
 
     pf_motion_control_platform_engine.reset_pose_reached();
     pf_motion_control_platform_engine.set_current_cycle(0);
@@ -546,6 +557,10 @@ void pf_handle_path_start([[maybe_unused]] const cogip::canpb::ReadBuffer& buffe
     // run between path start and pose_reached reset, see the stale 'reached'
     // value, and skip the first waypoint via PathManagerFilter.
     pf_motion_control_platform_engine.disable();
+
+    // Release any latched brake from a previous reached arrival so the new
+    // path runs the normal control chain instead of holding at zero speed.
+    pf_motion_control_platform_engine.set_brake(false);
 
     // Reset pose_reached before starting the path to avoid stale 'reached'
     pf_motion_control_platform_engine.reset_pose_reached();

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -183,50 +183,26 @@ static void pf_pose_reached_cb(const cogip::motion_control::target_pose_status_t
         }
         break;
 
-    case cogip::motion_control::target_pose_status_t::blocked: {
-        const cogip::path::Pose* current_waypoint = motion_control_path.current_pose();
-        const bool bypass_anti_blocking =
-            current_waypoint && current_waypoint->bypass_anti_blocking();
-        if (bypass_anti_blocking) {
-            // Replace the current waypoint with a hold-in-place one at the
-            // current robot pose, preserving every flag (motion_direction,
-            // bypass_final_orientation, is_intermediate...) of the original
-            // waypoint. Feeding the path manager with a target equal to
-            // current position lets PathManagerFilter → PoseStraightFilter
-            // converge immediately to FINISHED without trying to push the
-            // robot back against whatever is blocking it.
-            cogip::path::Pose hold = *current_waypoint;
-            hold.set_x(pf_motion_control_platform_engine.current_pose().x());
-            hold.set_y(pf_motion_control_platform_engine.current_pose().y());
-            hold.set_O(pf_motion_control_platform_engine.current_pose().O());
-            motion_control_path.reset();
-            motion_control_path.add_point(hold);
-            motion_control_path.start();
+    case cogip::motion_control::target_pose_status_t::blocked:
+        // The engine has already filtered out the bypass_anti_blocking case
+        // (it converts blocked to reached and replaces the current waypoint
+        // with a hold-in-place pose), so reaching this branch means a real
+        // blocked state with no bypass requested.
+        left_motor.set_speed(0);
+        right_motor.set_speed(0);
 
-            // Consider pose_reached as anti blocking is bypassed
-            pf_motion_control_platform_engine.set_pose_reached(
-                cogip::motion_control::target_pose_status_t::reached);
+        // As motors are stopped, pose straight filter state machine is in
+        // finished state (reset both chains as only one is active at a time)
+        quadpid_chain::pose_straight_filter.force_finished_state();
+        quadpid_tracker_chain::pose_straight_filter.force_finished_state();
 
-            LOG_WARNING("BLOCKED bypassed\n");
-        } else {
-            // Stop motors
-            left_motor.set_speed(0);
-            right_motor.set_speed(0);
+        LOG_WARNING("BLOCKED\n");
 
-            // As motors are stopped, pose straight filter state machine is in
-            // finished state (reset both chains as only one is active at a time)
-            quadpid_chain::pose_straight_filter.force_finished_state();
-            quadpid_tracker_chain::pose_straight_filter.force_finished_state();
-
-            LOG_WARNING("BLOCKED\n");
-
-            if (previous_target_pose_status !=
-                cogip::motion_control::target_pose_status_t::blocked) {
-                pf_get_canpb().send_message(blocked_uuid);
-            }
+        if (previous_target_pose_status !=
+            cogip::motion_control::target_pose_status_t::blocked) {
+            pf_get_canpb().send_message(blocked_uuid);
         }
         break;
-    }
 
     default:
         break;

--- a/platforms/pf-robot-motion-control/motion_control_parameters.cpp
+++ b/platforms/pf-robot-motion-control/motion_control_parameters.cpp
@@ -78,6 +78,14 @@ static const ParameterHandlerType::Registry registry = {
     {TRACKER_ANGULAR_SPEED_PID_KP_KEY, tracker_angular_speed_pid_kp},
     {TRACKER_ANGULAR_SPEED_PID_KI_KEY, tracker_angular_speed_pid_ki},
     {TRACKER_ANGULAR_SPEED_PID_KD_KEY, tracker_angular_speed_pid_kd},
+    // Brake linear speed PID
+    {BRAKE_LINEAR_SPEED_PID_KP_KEY, brake_linear_speed_pid_kp},
+    {BRAKE_LINEAR_SPEED_PID_KI_KEY, brake_linear_speed_pid_ki},
+    {BRAKE_LINEAR_SPEED_PID_KD_KEY, brake_linear_speed_pid_kd},
+    // Brake angular speed PID
+    {BRAKE_ANGULAR_SPEED_PID_KP_KEY, brake_angular_speed_pid_kp},
+    {BRAKE_ANGULAR_SPEED_PID_KI_KEY, brake_angular_speed_pid_ki},
+    {BRAKE_ANGULAR_SPEED_PID_KD_KEY, brake_angular_speed_pid_kd},
     /// Pose straight filter thresholds
     {LINEAR_THRESHOLD_KEY, param_linear_threshold},
     {ANGULAR_THRESHOLD_KEY, param_angular_threshold},


### PR DESCRIPTION
## Summary

- **Latch brake on reached**: once the platform engine reported a pose as reached, the normal control chain kept running and `process_outputs` kept firing reached callbacks every cycle. Holding the robot at the target was left to the tracking PID, which has zero pose Ki by construction (the cascade can't afford a second integrator) and silently drifts on slope, friction, or when another robot pushes against it. Latch the dedicated brake chain on the rising edge of the final `reached` status: from the next cycle on, `BaseControllerEngine` runs the `ZeroSpeedOrder + SpeedPID` brake chain instead of the tracking chain, actively driving the robot toward zero speed. While `brake_` is set, `process_outputs` skips pose_reached tracking, transition detection, logging and the callback dispatch entirely. `intermediate_reached` and `blocked` are left untouched so path navigation and host-level blocked handling keep their current semantics. Releasing the brake on a new motion is the API caller's job, not the engine setter's: `pf_handle_target_pose`, `pf_handle_speed_order`, `pf_handle_start_pose` and `pf_handle_path_start` now call `set_brake(false)` alongside the pre-existing reset of pose_reached so the next motion runs the normal control chain again.
- **Dedicate brake PIDParameters**: the brake speed PIDs ran their own integrator state but borrowed their gains from `quadpid_chain::*_speed_pid_parameters`, so any tuning of the brake loop also moved the tracking loop. Add `brake_*_speed_pid_kp/ki/kd/integral_limit` Parameters in robot1 and robot2 conf, initialised to the same values as the existing speed loop so behaviour is unchanged out of the box. `brake_chain.hpp` now builds its `PIDParameters` from those new Parameters, drops the include of `quadpid_chain.hpp`, and binds the `brake_*_speed_pid` PID instances on the dedicated parameters.