### PR TITLE
applications/robot-motion-control: add brake PID config for robots 3-6

### DIFF
--- a/applications/robot-motion-control/include/robot3_conf.hpp
+++ b/applications/robot-motion-control/include/robot3_conf.hpp
@@ -64,6 +64,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 10;
 constexpr float default_tracker_angular_speed_pid_ki = 1;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_ki = 1;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 10;
+constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 5;
 // Angular threshold
@@ -119,4 +134,14 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot4_conf.hpp
+++ b/applications/robot-motion-control/include/robot4_conf.hpp
@@ -63,6 +63,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 13;
 constexpr float default_tracker_angular_speed_pid_ki = 1;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_ki = 1;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 13;
+constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 5;
 // Angular threshold
@@ -118,4 +133,14 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot5_conf.hpp
+++ b/applications/robot-motion-control/include/robot5_conf.hpp
@@ -63,6 +63,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 10;
 constexpr float default_tracker_angular_speed_pid_ki = 1;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_ki = 1;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 10;
+constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 5;
 // Angular threshold
@@ -116,4 +131,14 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());

--- a/applications/robot-motion-control/include/robot6_conf.hpp
+++ b/applications/robot-motion-control/include/robot6_conf.hpp
@@ -63,6 +63,21 @@ constexpr float default_tracker_angular_speed_pid_kp = 10;
 constexpr float default_tracker_angular_speed_pid_ki = 1;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
+// ============================================================================
+// Brake chain PID gains (dedicated, runs while engine.brake_ is latched).
+// Initialised to the tracking values so behaviour is unchanged out of the
+// box; tuneable independently to fight static disturbances on hold.
+// ============================================================================
+
+// Linear speed PID (brake chain)
+constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_ki = 1;
+constexpr float default_brake_linear_speed_pid_kd = 0;
+// Angular speed PID (brake chain)
+constexpr float default_brake_angular_speed_pid_kp = 10;
+constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kd = 0;
+
 // Linear threshold
 constexpr float linear_threshold = 5;
 // Angular threshold
@@ -116,4 +131,14 @@ constexpr float default_tracker_linear_speed_pid_integral_limit =
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
         ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+
+// Brake speed PID integral limits
+constexpr float default_brake_linear_speed_pid_integral_limit =
+    (default_brake_linear_speed_pid_ki != 0)
+        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_angular_speed_pid_integral_limit =
+    (default_brake_angular_speed_pid_ki != 0)
+        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -198,8 +198,7 @@ static void pf_pose_reached_cb(const cogip::motion_control::target_pose_status_t
 
         LOG_WARNING("BLOCKED\n");
 
-        if (previous_target_pose_status !=
-            cogip::motion_control::target_pose_status_t::blocked) {
+        if (previous_target_pose_status != cogip::motion_control::target_pose_status_t::blocked) {
             pf_get_canpb().send_message(blocked_uuid);
         }
         break;


### PR DESCRIPTION
- Robot 2 already had dedicated brake-chain PID gains since the brake chain was split from the tracker speed loop; robots 3, 4, 5 and 6 were left without them and fell back to defaults.
- Mirror each robot's tracker speed gains into new brake gains so hold behaviour stays identical out of the box.
- Derive matching integral limits from the brake gains, opening the door to tune the brake chain independently against static disturbances without touching tracking dynamics.