### PR TITLE
Cup/2026 work on site

### DIFF
--- a/applications/robot-motion-control/include/robot1_conf.hpp
+++ b/applications/robot-motion-control/include/robot1_conf.hpp
@@ -48,11 +48,11 @@ constexpr float default_angular_speed_pid_kd = 0;
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
 // Ki helps eliminate steady-state error when tracker profile ends
-constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_kp = 0.15;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.3;
+constexpr float default_tracker_angular_pose_pid_kp = 0.15;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
@@ -60,8 +60,8 @@ constexpr float default_tracker_linear_speed_pid_kp = 3;
 constexpr float default_tracker_linear_speed_pid_ki = 0.8;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 5.5;
-constexpr float default_tracker_angular_speed_pid_ki = 0.6;
+constexpr float default_tracker_angular_speed_pid_kp = 6;
+constexpr float default_tracker_angular_speed_pid_ki = 0.9;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -71,12 +71,12 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 3.;
-constexpr float default_brake_linear_speed_pid_ki = 0.8;
+constexpr float default_brake_linear_speed_pid_kp = 6;
+constexpr float default_brake_linear_speed_pid_ki = 1;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 5.5;
-constexpr float default_brake_angular_speed_pid_ki = 0.6;
+constexpr float default_brake_angular_speed_pid_kp = 9;
+constexpr float default_brake_angular_speed_pid_ki = 1;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
@@ -93,14 +93,14 @@ constexpr double platform_linear_anti_blocking_error_threshold_mm_per_s = 50;
 constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
 // Speeds and accelerations/decelerations limits
-constexpr float min_speed_mm_per_s = 0;    ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 2000; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 500.0; ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 500.0; ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 1500;  ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 1250.0; ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 1250.0; ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Minimum speed (deg/s)
-constexpr float max_speed_deg_per_s = 720; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 720;  ///< Maximum acceleration (deg/s²)
+constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
+constexpr float max_acc_deg_per_s2 = 360;  ///< Maximum acceleration (deg/s²)
 constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
@@ -131,21 +131,9 @@ constexpr float default_tracker_linear_pose_pid_integral_limit =
         : (etl::numeric_limits<float>::max());
 constexpr float default_tracker_angular_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_speed_pid_integral_limit = 25;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 12;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 25;
+constexpr float default_brake_angular_speed_pid_integral_limit = 12;

--- a/applications/robot-motion-control/include/robot2_conf.hpp
+++ b/applications/robot-motion-control/include/robot2_conf.hpp
@@ -133,30 +133,52 @@ constexpr float default_linear_speed_pid_integral_limit =
 constexpr float default_angular_speed_pid_integral_limit =
     static_cast<float>(etl::numeric_limits<int16_t>::max());
 
+// Anti-windup caps for the tracker and brake chains.
+// The PID consumes errors in *_per_period (loop runs every motion_control_thread_period_ms
+// = 20 ms), and produces a speed contribution in the same unit. We size each integral
+// limit so the integral term alone can contribute up to 50% of the platform's max speed
+// at saturation:
+//
+//     I_contribution_max = integral_limit * ki = anti_windup_ratio * max_speed_per_period
+//
+// hence integral_limit = anti_windup_ratio * max_speed_per_period / ki, with
+// max_speed_per_period = max_speed_per_s * (loop_period_ms / 1000).
+constexpr float anti_windup_ratio = 0.5f;
+constexpr float loop_period_ms_for_iwindup = 20.f; // must match motion_control_thread_period_ms
+constexpr float max_speed_mm_per_period_for_iwindup =
+    max_speed_mm_per_s * loop_period_ms_for_iwindup / 1000.f;
+constexpr float max_speed_deg_per_period_for_iwindup =
+    max_speed_deg_per_s * loop_period_ms_for_iwindup / 1000.f;
+
 // Tracker PID integral limits
 constexpr float default_tracker_linear_pose_pid_integral_limit =
     (default_tracker_linear_pose_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_pose_pid_ki)
+        ? (anti_windup_ratio * max_speed_mm_per_period_for_iwindup /
+           default_tracker_linear_pose_pid_ki)
         : (etl::numeric_limits<float>::max());
 constexpr float default_tracker_angular_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
 constexpr float default_tracker_linear_speed_pid_integral_limit =
     (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
+        ? (anti_windup_ratio * max_speed_mm_per_period_for_iwindup /
+           default_tracker_linear_speed_pid_ki)
         : (etl::numeric_limits<float>::max());
 constexpr float default_tracker_angular_speed_pid_integral_limit =
     (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
+        ? (anti_windup_ratio * max_speed_deg_per_period_for_iwindup /
+           default_tracker_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());
 
 // Brake speed PID integral limits
 constexpr float default_brake_linear_speed_pid_integral_limit =
     (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
+        ? (anti_windup_ratio * max_speed_mm_per_period_for_iwindup /
+           default_brake_linear_speed_pid_ki)
         : (etl::numeric_limits<float>::max());
 constexpr float default_brake_angular_speed_pid_integral_limit =
     (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
+        ? (anti_windup_ratio * max_speed_deg_per_period_for_iwindup /
+           default_brake_angular_speed_pid_ki)
         : (etl::numeric_limits<float>::max());
 
 // ============================================================================

--- a/applications/robot-motion-control/include/robot2_conf.hpp
+++ b/applications/robot-motion-control/include/robot2_conf.hpp
@@ -58,16 +58,16 @@ constexpr float default_tracker_linear_pose_pid_kp = 0.25;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.15;
+constexpr float default_tracker_angular_pose_pid_kp = 0.25;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
 constexpr float default_tracker_linear_speed_pid_kp = 1;
-constexpr float default_tracker_linear_speed_pid_ki = 0.1;
+constexpr float default_tracker_linear_speed_pid_ki = 0.3;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 1;
-constexpr float default_tracker_angular_speed_pid_ki = 0.1;
+constexpr float default_tracker_angular_speed_pid_kp = 1.2;
+constexpr float default_tracker_angular_speed_pid_ki = 0.45;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -77,21 +77,21 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 1;
-constexpr float default_brake_linear_speed_pid_ki = 0.1;
+constexpr float default_brake_linear_speed_pid_kp = 1.5;
+constexpr float default_brake_linear_speed_pid_ki = 0.3;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 1;
-constexpr float default_brake_angular_speed_pid_ki = 0.1;
+constexpr float default_brake_angular_speed_pid_kp = 1.2;
+constexpr float default_brake_angular_speed_pid_ki = 0.45;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
-constexpr float linear_threshold = 3;
+constexpr float linear_threshold = 2;
 // Angular threshold
 constexpr float angular_threshold = 1;
 // Angular intermediate threshold (when the robot turns on itself to go straight
 // to its destination)
-constexpr float angular_intermediate_threshold = 5;
+constexpr float angular_intermediate_threshold = 2;
 
 // Linear anti-blocking
 constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_s = 0;
@@ -104,15 +104,15 @@ constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 655
 // PID; the 360 deg/s angular cap matches a wheel velocity of ~410 mm/s in
 // pure rotation, which stays inside the linear budget when combined with
 // translation.
-constexpr float min_speed_mm_per_s = 0;    ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 500;  ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 500.0; ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 250.0; ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 1000;  ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 1000.0; ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 500.0;  ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Minimum speed (deg/s)
 constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 360;  ///< Maximum acceleration (deg/s²)
-constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
+constexpr float max_acc_deg_per_s2 = 720;  ///< Maximum acceleration (deg/s²)
+constexpr float max_dec_deg_per_s2 = 720;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
 /// The filters clamp at ratio × nominal max to catch runaway values
@@ -158,28 +158,12 @@ constexpr float default_tracker_linear_pose_pid_integral_limit =
         : (etl::numeric_limits<float>::max());
 constexpr float default_tracker_angular_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (anti_windup_ratio * max_speed_mm_per_period_for_iwindup /
-           default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (anti_windup_ratio * max_speed_deg_per_period_for_iwindup /
-           default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 6;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (anti_windup_ratio * max_speed_mm_per_period_for_iwindup /
-           default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (anti_windup_ratio * max_speed_deg_per_period_for_iwindup /
-           default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_brake_angular_speed_pid_integral_limit = 6;
 
 // ============================================================================
 // Localization (OTOS optical tracking sensor)

--- a/applications/robot-motion-control/include/robot3_conf.hpp
+++ b/applications/robot-motion-control/include/robot3_conf.hpp
@@ -91,10 +91,10 @@ constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_s = 12.5;
 constexpr double platform_linear_anti_blocking_error_threshold_mm_per_s = 50;
 constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
-constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 300.0; ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 300.0;  ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 300.0;  ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
 constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)

--- a/applications/robot-motion-control/include/robot3_conf.hpp
+++ b/applications/robot-motion-control/include/robot3_conf.hpp
@@ -48,20 +48,20 @@ constexpr float default_angular_speed_pid_kd = 0.0;
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_kp = 0.2;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_kp = 0.15;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_kp = 8;
 constexpr float default_tracker_linear_speed_pid_ki = 1;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 10;
-constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kp = 9;
+constexpr float default_tracker_angular_speed_pid_ki = 5;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -71,12 +71,12 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_kp = 8;
 constexpr float default_brake_linear_speed_pid_ki = 1;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 10;
-constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kp = 9;
+constexpr float default_brake_angular_speed_pid_ki = 5;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
@@ -94,12 +94,12 @@ constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
 constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
 constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 1000.0;  ///< Maximum deceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
 
-constexpr float min_speed_deg_per_s = 20;  ///< Maximum speed (deg/s)
-constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 180;  ///< Maximum acceleration (deg/s²)
-constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
+constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
+constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)
+constexpr float max_acc_deg_per_s2 = 270;  ///< Maximum acceleration (deg/s²)
+constexpr float max_dec_deg_per_s2 = 270;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
 /// The filters clamp at ratio × nominal max to catch runaway values
@@ -127,21 +127,9 @@ constexpr float default_tracker_linear_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
 constexpr float default_tracker_angular_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 8;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_brake_angular_speed_pid_integral_limit = 8;

--- a/applications/robot-motion-control/include/robot4_conf.hpp
+++ b/applications/robot-motion-control/include/robot4_conf.hpp
@@ -43,24 +43,25 @@ constexpr float default_angular_speed_pid_ki = 1;
 constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
-// Tracker chain PID gains (QUADPID_TRACKER)
+// Tracker pose PID gains (QUADPID_TRACKER - tracker branch)
+// Used to track the motion profile in real-time (closed-loop tracking)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_kp = 0.2;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_kp = 0.15;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_kp = 8;
 constexpr float default_tracker_linear_speed_pid_ki = 1;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 13;
-constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kp = 9;
+constexpr float default_tracker_angular_speed_pid_ki = 5;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -70,12 +71,12 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_kp = 8;
 constexpr float default_brake_linear_speed_pid_ki = 1;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 13;
-constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kp = 9;
+constexpr float default_brake_angular_speed_pid_ki = 5;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
@@ -93,12 +94,12 @@ constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
 constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
 constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 1000.0;  ///< Maximum deceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
 
-constexpr float min_speed_deg_per_s = 20;  ///< Maximum speed (deg/s)
-constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 180;  ///< Maximum acceleration (deg/s²)
-constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
+constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
+constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)
+constexpr float max_acc_deg_per_s2 = 270;  ///< Maximum acceleration (deg/s²)
+constexpr float max_dec_deg_per_s2 = 270;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
 /// The filters clamp at ratio × nominal max to catch runaway values
@@ -126,21 +127,9 @@ constexpr float default_tracker_linear_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
 constexpr float default_tracker_angular_pose_pid_integral_limit =
     etl::numeric_limits<uint16_t>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 8;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_brake_angular_speed_pid_integral_limit = 8;

--- a/applications/robot-motion-control/include/robot4_conf.hpp
+++ b/applications/robot-motion-control/include/robot4_conf.hpp
@@ -91,10 +91,10 @@ constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_s = 12.5;
 constexpr double platform_linear_anti_blocking_error_threshold_mm_per_s = 50;
 constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
-constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 300.0; ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 300.0;  ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 300.0;  ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
 constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)

--- a/applications/robot-motion-control/include/robot5_conf.hpp
+++ b/applications/robot-motion-control/include/robot5_conf.hpp
@@ -91,10 +91,10 @@ constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_s = 12.5;
 constexpr double platform_linear_anti_blocking_error_threshold_mm_per_s = 50;
 constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
-constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 300.0; ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 300.0;  ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 300.0;  ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
 constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)

--- a/applications/robot-motion-control/include/robot5_conf.hpp
+++ b/applications/robot-motion-control/include/robot5_conf.hpp
@@ -43,24 +43,25 @@ constexpr float default_angular_speed_pid_ki = 1;
 constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
-// Tracker chain PID gains (QUADPID_TRACKER)
+// Tracker pose PID gains (QUADPID_TRACKER - tracker branch)
+// Used to track the motion profile in real-time (closed-loop tracking)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_kp = 0.2;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_kp = 0.15;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_kp = 8;
 constexpr float default_tracker_linear_speed_pid_ki = 1;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 10;
-constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kp = 9;
+constexpr float default_tracker_angular_speed_pid_ki = 5;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -70,12 +71,12 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_kp = 8;
 constexpr float default_brake_linear_speed_pid_ki = 1;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 10;
-constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kp = 9;
+constexpr float default_brake_angular_speed_pid_ki = 5;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
@@ -93,12 +94,12 @@ constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
 constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
 constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 1000.0;  ///< Maximum deceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
 
-constexpr float min_speed_deg_per_s = 20;  ///< Maximum speed (deg/s)
-constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 180;  ///< Maximum acceleration (deg/s²)
-constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
+constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
+constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)
+constexpr float max_acc_deg_per_s2 = 270;  ///< Maximum acceleration (deg/s²)
+constexpr float max_dec_deg_per_s2 = 270;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
 /// The filters clamp at ratio × nominal max to catch runaway values
@@ -112,8 +113,8 @@ constexpr bool platform_linear_antiblocking = false;
 constexpr bool angular_antiblocking = false;
 
 // PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
-constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
 constexpr float default_linear_speed_pid_integral_limit =
     (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
                                        : (etl::numeric_limits<float>::max());
@@ -122,23 +123,13 @@ constexpr float default_angular_speed_pid_integral_limit =
                                         : (etl::numeric_limits<float>::max());
 
 // Tracker PID integral limits
-constexpr float default_tracker_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_tracker_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 8;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_brake_angular_speed_pid_integral_limit = 8;

--- a/applications/robot-motion-control/include/robot6_conf.hpp
+++ b/applications/robot-motion-control/include/robot6_conf.hpp
@@ -91,10 +91,10 @@ constexpr double platform_linear_anti_blocking_speed_threshold_mm_per_s = 12.5;
 constexpr double platform_linear_anti_blocking_error_threshold_mm_per_s = 50;
 constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
-constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
-constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
+constexpr float min_speed_mm_per_s = 0;     ///< Minimum speed (mm/s)
+constexpr float max_speed_mm_per_s = 300.0; ///< Maximum speed (mm/s)
+constexpr float max_acc_mm_per_s2 = 300.0;  ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 300.0;  ///< Maximum deceleration (mm/s²)
 
 constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
 constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)

--- a/applications/robot-motion-control/include/robot6_conf.hpp
+++ b/applications/robot-motion-control/include/robot6_conf.hpp
@@ -43,24 +43,25 @@ constexpr float default_angular_speed_pid_ki = 1;
 constexpr float default_angular_speed_pid_kd = 0.0;
 
 // ============================================================================
-// Tracker chain PID gains (QUADPID_TRACKER)
+// Tracker pose PID gains (QUADPID_TRACKER - tracker branch)
+// Used to track the motion profile in real-time (closed-loop tracking)
 // ============================================================================
 
 // Tracker linear pose PID (tracker during MOVE_TO_POSITION)
-constexpr float default_tracker_linear_pose_pid_kp = 0.1;
+constexpr float default_tracker_linear_pose_pid_kp = 0.2;
 constexpr float default_tracker_linear_pose_pid_ki = 0.0;
 constexpr float default_tracker_linear_pose_pid_kd = 0;
 // Tracker angular pose PID (tracker during ROTATE states)
-constexpr float default_tracker_angular_pose_pid_kp = 0.2;
+constexpr float default_tracker_angular_pose_pid_kp = 0.15;
 constexpr float default_tracker_angular_pose_pid_ki = 0;
 constexpr float default_tracker_angular_pose_pid_kd = 0;
 // Tracker linear speed PID
-constexpr float default_tracker_linear_speed_pid_kp = 10;
+constexpr float default_tracker_linear_speed_pid_kp = 8;
 constexpr float default_tracker_linear_speed_pid_ki = 1;
 constexpr float default_tracker_linear_speed_pid_kd = 0;
 // Tracker angular speed PID
-constexpr float default_tracker_angular_speed_pid_kp = 10;
-constexpr float default_tracker_angular_speed_pid_ki = 1;
+constexpr float default_tracker_angular_speed_pid_kp = 9;
+constexpr float default_tracker_angular_speed_pid_ki = 5;
 constexpr float default_tracker_angular_speed_pid_kd = 0;
 
 // ============================================================================
@@ -70,12 +71,12 @@ constexpr float default_tracker_angular_speed_pid_kd = 0;
 // ============================================================================
 
 // Linear speed PID (brake chain)
-constexpr float default_brake_linear_speed_pid_kp = 10;
+constexpr float default_brake_linear_speed_pid_kp = 8;
 constexpr float default_brake_linear_speed_pid_ki = 1;
 constexpr float default_brake_linear_speed_pid_kd = 0;
 // Angular speed PID (brake chain)
-constexpr float default_brake_angular_speed_pid_kp = 10;
-constexpr float default_brake_angular_speed_pid_ki = 1;
+constexpr float default_brake_angular_speed_pid_kp = 9;
+constexpr float default_brake_angular_speed_pid_ki = 5;
 constexpr float default_brake_angular_speed_pid_kd = 0;
 
 // Linear threshold
@@ -92,13 +93,13 @@ constexpr double platform_linear_anti_blocking_blocked_cycles_nb_threshold = 10;
 
 constexpr float min_speed_mm_per_s = 0;      ///< Minimum speed (mm/s)
 constexpr float max_speed_mm_per_s = 1000.0; ///< Maximum speed (mm/s)
-constexpr float max_acc_mm_per_s2 = 250.0;   ///< Maximum acceleration (mm/s²)
-constexpr float max_dec_mm_per_s2 = 250.0;   ///< Maximum deceleration (mm/s²)
+constexpr float max_acc_mm_per_s2 = 750.0;   ///< Maximum acceleration (mm/s²)
+constexpr float max_dec_mm_per_s2 = 750.0;   ///< Maximum deceleration (mm/s²)
 
-constexpr float min_speed_deg_per_s = 20;  ///< Maximum speed (deg/s)
-constexpr float max_speed_deg_per_s = 360; ///< Maximum speed (deg/s)
-constexpr float max_acc_deg_per_s2 = 180;  ///< Maximum acceleration (deg/s²)
-constexpr float max_dec_deg_per_s2 = 360;  ///< Maximum deceleration (deg/s²)
+constexpr float min_speed_deg_per_s = 0;   ///< Maximum speed (deg/s)
+constexpr float max_speed_deg_per_s = 180; ///< Maximum speed (deg/s)
+constexpr float max_acc_deg_per_s2 = 270;  ///< Maximum acceleration (deg/s²)
+constexpr float max_dec_deg_per_s2 = 270;  ///< Maximum deceleration (deg/s²)
 
 /// Safety clamp ratio for speed/acceleration filters
 /// The filters clamp at ratio × nominal max to catch runaway values
@@ -112,8 +113,8 @@ constexpr bool platform_linear_antiblocking = false;
 constexpr bool angular_antiblocking = false;
 
 // PID integral limits (use float max when ki == 0 to avoid constexpr div-by-zero)
-constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
+constexpr float default_linear_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
+constexpr float default_angular_pose_pid_integral_limit = etl::numeric_limits<uint16_t>::max();
 constexpr float default_linear_speed_pid_integral_limit =
     (default_linear_speed_pid_ki != 0) ? (max_speed_mm_per_s / default_linear_speed_pid_ki)
                                        : (etl::numeric_limits<float>::max());
@@ -122,23 +123,13 @@ constexpr float default_angular_speed_pid_integral_limit =
                                         : (etl::numeric_limits<float>::max());
 
 // Tracker PID integral limits
-constexpr float default_tracker_linear_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_tracker_angular_pose_pid_integral_limit = etl::numeric_limits<float>::max();
-constexpr float default_tracker_linear_speed_pid_integral_limit =
-    (default_tracker_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_tracker_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_tracker_angular_speed_pid_integral_limit =
-    (default_tracker_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_tracker_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_tracker_linear_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_angular_pose_pid_integral_limit =
+    etl::numeric_limits<uint16_t>::max();
+constexpr float default_tracker_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_tracker_angular_speed_pid_integral_limit = 8;
 
 // Brake speed PID integral limits
-constexpr float default_brake_linear_speed_pid_integral_limit =
-    (default_brake_linear_speed_pid_ki != 0)
-        ? (max_speed_mm_per_s / default_brake_linear_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
-constexpr float default_brake_angular_speed_pid_integral_limit =
-    (default_brake_angular_speed_pid_ki != 0)
-        ? (max_speed_deg_per_s / default_brake_angular_speed_pid_ki)
-        : (etl::numeric_limits<float>::max());
+constexpr float default_brake_linear_speed_pid_integral_limit = 17.5;
+constexpr float default_brake_angular_speed_pid_integral_limit = 8;

--- a/lib/actuator/Lift.cpp
+++ b/lib/actuator/Lift.cpp
@@ -112,6 +112,15 @@ void Lift::actuate(int32_t command)
 
     LOG_INFO("Move lift to clamped command %" PRIi32 "\n", clamped);
 
+    // Disable anti-blocking when going up: lifting weight against gravity
+    // makes legitimate stalls hard to distinguish from extra load, and we
+    // would rather let the motion finish on its own than trigger a false
+    // BLOCKED on every ascent. Descents stay protected.
+    if (params_.motor_params.anti_blocking_parameters) {
+        const bool going_up = static_cast<float>(clamped) > get_current_distance();
+        params_.motor_params.anti_blocking_parameters->set_enabled(!going_up);
+    }
+
     last_command_ = clamped;
     Motor::actuate(clamped);
 }

--- a/motion_control/controllers/target_change_detector/include/target_change_detector/TargetChangeDetector.hpp
+++ b/motion_control/controllers/target_change_detector/include/target_change_detector/TargetChangeDetector.hpp
@@ -78,7 +78,10 @@ class TargetChangeDetector
     /// Keep previous_values_ and first_run_ unchanged so that a reset
     /// does not spuriously trigger new_target on the next execute().
     /// Only a real change in watched keys should trigger new_target.
-    void reset() override {}
+    void reset() override
+    {
+        first_run_ = true;
+    }
 
     /// @brief Execute target change detection
     void execute(ControllersIO& io) override

--- a/motion_control/engines/motor_engine/MotorEngine.cpp
+++ b/motion_control/engines/motor_engine/MotorEngine.cpp
@@ -94,40 +94,45 @@ void MotorEngine::process_outputs()
         gpio_clear(clear_overload_pin_);
     }
 
-    // If timeout is enabled, pose_reached_ has been set by the engine itself, do
-    // not override it.
-    if (pose_reached_ != target_pose_status_t::timeout) {
+    // Once a terminal state (timeout or blocked) is latched, freeze
+    // pose_reached_ on it until the next set_target_distance() clears the
+    // latch. Otherwise the downstream pose loop, which sees target ==
+    // current after the hold-in-place reset below, would write `reached`
+    // to IO on the very next cycle and trigger a spurious `reached`
+    // callback right after the failure notification.
+    if (pose_reached_ != target_pose_status_t::timeout &&
+        pose_reached_ != target_pose_status_t::blocked) {
         pose_reached_ = io_.get_as<target_pose_status_t>("pose_reached").value();
-    } else {
-        LOG_ERROR("MotorEngine timed out, hold. current=%.2f target=%.2f\n",
-                  static_cast<double>(odometer_.distance_mm()),
-                  static_cast<double>(target_distance_));
+    }
 
-        if (previous_pose_reached_ != target_pose_status_t::timeout &&
-            pose_reached_cb_.is_valid()) {
-            pose_reached_cb_(target_pose_status_t::timeout);
+    if (pose_reached_ == target_pose_status_t::timeout) {
+        if (previous_pose_reached_ != target_pose_status_t::timeout) {
+            LOG_ERROR("MotorEngine timed out, hold. current=%.2f target=%.2f\n",
+                      static_cast<double>(odometer_.distance_mm()),
+                      static_cast<double>(target_distance_));
+            if (pose_reached_cb_.is_valid()) {
+                pose_reached_cb_(target_pose_status_t::timeout);
+            }
         }
 
         // Hold current position: set target to where we are and let the control loop maintain it
         target_distance_ = odometer_.distance_mm();
         timeout_enable_ = false;
-        pose_reached_ = target_pose_status_t::moving;
     }
 
     if (pose_reached_ == target_pose_status_t::blocked) {
-        LOG_ERROR("MotorEngine blocked, hold. current=%.2f target=%.2f\n",
-                  static_cast<double>(odometer_.distance_mm()),
-                  static_cast<double>(target_distance_));
-
-        if (previous_pose_reached_ != target_pose_status_t::blocked &&
-            pose_reached_cb_.is_valid()) {
-            pose_reached_cb_(target_pose_status_t::blocked);
+        if (previous_pose_reached_ != target_pose_status_t::blocked) {
+            LOG_ERROR("MotorEngine blocked, hold. current=%.2f target=%.2f\n",
+                      static_cast<double>(odometer_.distance_mm()),
+                      static_cast<double>(target_distance_));
+            if (pose_reached_cb_.is_valid()) {
+                pose_reached_cb_(target_pose_status_t::blocked);
+            }
         }
 
         // Hold current position: set target to where we are and let the control loop maintain it
         target_distance_ = odometer_.distance_mm();
         timeout_enable_ = false;
-        pose_reached_ = target_pose_status_t::moving;
     }
 
     // Notify once per target when pose is first reached

--- a/motion_control/filters/pose_straight_filter/PoseStraightFilter.cpp
+++ b/motion_control/filters/pose_straight_filter/PoseStraightFilter.cpp
@@ -212,6 +212,13 @@ void PoseStraightFilter::execute(ControllersIO& io)
     if ((current_state_ == PoseStraightFilterState::ROTATE_TO_DIRECTION) &&
         (absolute_linear_pose_error <= linear_threshold)) {
         current_state_ = PoseStraightFilterState::ROTATE_TO_FINAL_ANGLE;
+        // Reset speed and pose PIDs so the integral charged by the
+        // anti-drift longitudinal correction during ROTATE_TO_DIRECTION
+        // does not leak into the final orientation phase.
+        io.set(keys_.linear_speed_pid_reset, true);
+        io.set(keys_.angular_speed_pid_reset, true);
+        io.set(keys_.linear_pose_pid_reset, true);
+        io.set(keys_.angular_pose_pid_reset, true);
         angular_recompute_profile = true;
         linear_recompute_profile = true;
         DEBUG("Early transition to ROTATE_TO_FINAL_ANGLE (already at position, linear_err=%.2f "

--- a/motion_control/metas/conditional_switch_meta_controller/include/conditional_switch_meta_controller/ConditionalSwitchMetaController.hpp
+++ b/motion_control/metas/conditional_switch_meta_controller/include/conditional_switch_meta_controller/ConditionalSwitchMetaController.hpp
@@ -77,6 +77,19 @@ class ConditionalSwitchMetaController : public BaseController
         return "ConditionalSwitchMetaController";
     }
 
+    /// @brief Reset both child controllers.
+    /// Both branches must be reset because either one may be selected on the
+    /// next execute(), and we cannot know in advance which.
+    void reset() override
+    {
+        if (controller_when_true_) {
+            controller_when_true_->reset();
+        }
+        if (controller_when_false_) {
+            controller_when_false_->reset();
+        }
+    }
+
     /// @brief Dump the controller hierarchy to stdout as ASCII tree
     /// @param indent Current indentation level
     /// @param is_last Whether this is the last child at current level

--- a/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
@@ -65,7 +65,10 @@ class BaseControllerEngine
 
     /// Latch or clear the brake state. When latched, the engine executes
     /// the brake controller chain instead of the normal one; it stays
-    /// latched until an explicit set_brake(false) is issued.
+    /// latched until an explicit set_brake(false) is issued. On the
+    /// false→true edge the brake controller is reset so any controller
+    /// with internal state (e.g. a speed ramp capturing the current
+    /// measured speed) re-arms from scratch.
     void set_brake(bool brake)
     {
         mutex_lock(&mutex_);
@@ -79,7 +82,11 @@ class BaseControllerEngine
     /// set_brake() would re-lock the non-recursive mutex and deadlock.
     void set_brake_locked(bool brake)
     {
+        const bool rising_edge = !brake_ && brake;
         brake_ = brake;
+        if (rising_edge && brake_controller_) {
+            brake_controller_->reset();
+        }
     };
 
     /// Return whether the brake is currently latched

--- a/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
+++ b/motion_control/motion_control_common/include/motion_control_common/BaseControllerEngine.hpp
@@ -69,8 +69,17 @@ class BaseControllerEngine
     void set_brake(bool brake)
     {
         mutex_lock(&mutex_);
-        brake_ = brake;
+        set_brake_locked(brake);
         mutex_unlock(&mutex_);
+    };
+
+    /// Same as set_brake(), but assumes the engine mutex is already held by
+    /// the caller. Use from callbacks invoked under the engine loop (e.g.
+    /// pose_reached_cb_ from PlatformEngine::process_outputs), where calling
+    /// set_brake() would re-lock the non-recursive mutex and deadlock.
+    void set_brake_locked(bool brake)
+    {
+        brake_ = brake;
     };
 
     /// Return whether the brake is currently latched

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -191,10 +191,7 @@ static void pf_pose_reached_cb(const cogip::motion_control::target_pose_status_t
         left_motor.set_speed(0);
         right_motor.set_speed(0);
 
-        // As motors are stopped, pose straight filter state machine is in
-        // finished state (reset both chains as only one is active at a time)
-        quadpid_chain::pose_straight_filter.force_finished_state();
-        quadpid_tracker_chain::pose_straight_filter.force_finished_state();
+        pf_motion_control_platform_engine.set_brake(true);
 
         LOG_WARNING("BLOCKED\n");
 
@@ -307,11 +304,7 @@ void pf_send_encoder_telemetry(void)
 
 void pf_handle_brake([[maybe_unused]] const cogip::canpb::ReadBuffer& buffer)
 {
-    pf_motion_control_platform_engine.set_target_speed(cogip::cogip_defs::Polar(0, 0));
-
-    // Reset both chains as only one is active at a time
-    quadpid_chain::pose_straight_filter.force_finished_state();
-    quadpid_tracker_chain::pose_straight_filter.force_finished_state();
+    pf_motion_control_platform_engine.set_brake(true);
 }
 
 void pf_handle_game_end([[maybe_unused]] const cogip::canpb::ReadBuffer& buffer)
@@ -332,10 +325,6 @@ void pf_handle_game_end([[maybe_unused]] const cogip::canpb::ReadBuffer& buffer)
     default:
         break;
     }
-
-    // Force position filter finished state (reset both chains as only one is active at a time)
-    quadpid_chain::pose_straight_filter.force_finished_state();
-    quadpid_tracker_chain::pose_straight_filter.force_finished_state();
 
     // Disable motion control to avoid new motion
     pf_disable_motion_control();

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -611,6 +611,17 @@ void pf_disable_motion_control()
     LOG_INFO("[DISABLE] Disabling motion control\n");
     pf_motion_control_platform_engine.disable();
 
+    // Release any latched brake so re-enabling the engine resumes the
+    // normal control chain instead of staying on the brake chain.
+    pf_motion_control_platform_engine.set_brake(false);
+
+    // PoseStraightFilter::reset() leaves current_state_ untouched (only
+    // TargetChangeDetector re-arms it on a new_target). Without a forced
+    // FINISHED here, re-enabling without a new pose order would resume the
+    // previous stale state machine.
+    quadpid_chain::pose_straight_filter.force_finished_state();
+    quadpid_tracker_chain::pose_straight_filter.force_finished_state();
+
     // Disable motors
     left_motor.disable();
     right_motor.disable();

--- a/platforms/pf-robot-motion-control/motion_control.cpp
+++ b/platforms/pf-robot-motion-control/motion_control.cpp
@@ -191,7 +191,10 @@ static void pf_pose_reached_cb(const cogip::motion_control::target_pose_status_t
         left_motor.set_speed(0);
         right_motor.set_speed(0);
 
-        pf_motion_control_platform_engine.set_brake(true);
+        // This callback runs under the engine mutex (taken by thread_loop),
+        // so we cannot call set_brake() here — that would re-lock the same
+        // non-recursive mutex and deadlock the engine thread.
+        pf_motion_control_platform_engine.set_brake_locked(true);
 
         LOG_WARNING("BLOCKED\n");
 


### PR DESCRIPTION
### Changes

- **Latch terminal states in MotorEngine:** pin pose_reached_ on the terminal (blocked/timeout) state until the next set_target_distance(), and skip the IO read while latched, so an upstream reached write can no longer leak through and fire a spurious success callback right after a failure. Error log moved inside the first-cycle guard to stop per-cycle spam.
- **Re-arm target change detector after reset:** a chain reset now sets first_run_ back to true so the next execute() refreshes cached values and re-arms new_target, even when the incoming target equals the last cached one (typical after a brake hold). Prevents the robot lurching forward on resume with a stale profile.
- **Engage brake chain instead of forcing filters finished:** blocked, manual-brake and game-end paths now call set_brake(true) so the platform engine swaps to the dedicated brake chain and actively drives motors to zero, replacing the old force_finished_state() plus hand-zeroing workarounds.
- **Add set_brake_locked() variant:** fixes the deadlock where the pose-reached callback (running under the engine mutex) called set_brake() and re-locked the same non-recursive mutex. Public set_brake() keeps its locking contract.
- **Reset brake controller on latch:** reset the brake controller on the false-to-true edge so the brake speed ramp captures the actual current speed instead of reusing stale state from the previous episode.
- **Clean brake state on disable:** release any latched brake and force both pose-straight filters to FINISHED on pf_disable_motion_control(), so re-enabling resumes the normal chain from a clean state.
- **Reset PIDs on early pose transition:** reset pose and speed PIDs when PoseStraightFilter jumps straight to ROTATE_TO_FINAL_ANGLE, so the anti-drift integral from the first rotation does not bias the final orientation.
- **Add reset to conditional switch meta-controller:** override the previously no-op reset() to propagate to both child branches, since either may be selected on the next execute().
- **Skip anti-blocking on lift ascent:** toggle the anti-blocking detector by move direction so slow gravity-loaded ascents are not mistaken for a stall; descents stay protected.
- **Fix speed PID integral windup:** size the tracker/brake integral caps in per_period units instead of per_s, removing the ~50x over-wind that caused start kicks and long bleed on direction reversal; limits replaced with empirically validated values.
- **Motion tuning:** cup-readiness retuning of robot 1, robot 2 (initial plus on-site round) and PAMI robots 3-6, with rebalanced tracker/brake PID gains, tightened pose thresholds, and revised speed/acceleration envelopes per chassis.
- **Cap PAMI speeds for homologation:** lower linear speed/acceleration limits on PAMI robots 3-6 so they move slowly and predictably during the homologation run.